### PR TITLE
Incorporated external requirement step into Dockerfile 

### DIFF
--- a/credential-registry/server/django-icat-api/Dockerfile
+++ b/credential-registry/server/django-icat-api/Dockerfile
@@ -1,4 +1,11 @@
-FROM bcgovimages/von-image:py36-1.7-ew-0-s2i
+# TODO: remove the step once a package is available on PyPi
+# package pre-requirements
+FROM python:3.7-alpine as packager
+WORKDIR /tmp/django-icat-api
+ADD . .
+RUN python setup.py sdist
 
-ADD dist dist
+# building indy cat indy api image
+FROM bcgovimages/von-image:py36-1.7-ew-0-s2i
+COPY --from=packager /tmp/django-icat-api/dist dist
 RUN pip install dist/django-icat-api-0.1.tar.gz

--- a/credential-registry/server/icat-py-build.sh
+++ b/credential-registry/server/icat-py-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-cd django-icat-api/
-python setup.py sdist
-
-cd ../python-indy-api/
-python setup.py sdist
-

--- a/credential-registry/server/python-indy-api/Dockerfile
+++ b/credential-registry/server/python-indy-api/Dockerfile
@@ -1,4 +1,11 @@
-FROM indycat-api-build
+# TODO: remove the step once a package is available on PyPi
+# package pre-requirements
+FROM python:3.7-alpine as packager
+WORKDIR /tmp/python-indy-api
+ADD . .
+RUN python setup.py sdist
 
-ADD dist dist
+# build indy cat api image
+FROM indycat-api-build
+COPY --from=packager /tmp/python-indy-api/dist dist
 RUN pip install dist/python-indy-api-0.1.tar.gz

--- a/starter-kits/credential-registry/docker/manage
+++ b/starter-kits/credential-registry/docker/manage
@@ -254,24 +254,10 @@ build-schema-spy() {
     -t 'schema-spy'
 }
 
-build-api-pre-requisites() {
-  #
-  # Create the python package that will be installed in tob-api
-  # TODO: replace this once the package is published on PyPi
-  #
-  PRE_WORKING_DIR=`pwd`  
-  echo -e "\nBuilding pre-requisites for indy cat api image ..."
-  cd '../../../credential-registry/server' 
-  ./icat-py-build.sh
-  cd $PRE_WORKING_DIR
-}
-
 build-api() {
   #
   # tob-api
   #
-  build-api-pre-requisites
-
   echo -e "\nBuilding indy cat api image ..."
   docker build -q \
     -t 'indycat-api-build' \


### PR DESCRIPTION
This removes the requirement to manually build the `dist` folders for for django-icat-api and python-indy-api.

@ianco 