### PR TITLE
Add Dockerfile filter to fix file permissions for .sh files

### DIFF
--- a/credential-registry/server/Dockerfile
+++ b/credential-registry/server/Dockerfile
@@ -1,0 +1,5 @@
+# this is a "filer" Dockerfile, used to ensure file permissions
+# are set correctly on the final tob-api (django) image
+FROM django:latest
+
+RUN find . -name "*.sh" -exec chmod +x '{}' \;

--- a/starter-kits/credential-registry/docker/manage
+++ b/starter-kits/credential-registry/docker/manage
@@ -262,12 +262,14 @@ build-api() {
   docker build -q \
     -t 'indycat-api-build' \
     -f '../../../credential-registry/server/django-icat-api/Dockerfile' '../../../credential-registry/server/django-icat-api/'
+  
   echo -e "\nBuilding indy cat indy api image ..."
   docker build -q \
     -t 'indycat-indyapi-build' \
     -f '../../../credential-registry/server/python-indy-api/Dockerfile' '../../../credential-registry/server/python-indy-api/'
+  
   BASE_IMAGE="indycat-indyapi-build"
-  #BASE_IMAGE="bcgovimages/von-image:py36-1.7-ew-0-s2i"
+  
   echo -e "\nBuilding django image from ${BASE_IMAGE}..."
   ${S2I_EXE} build \
     -e "HTTP_PROXY=${HTTP_PROXY}" \
@@ -277,6 +279,13 @@ build-api() {
     '../server/tob-api' \
     "$BASE_IMAGE" \
     'django'
+  
+  # this is only required in Windows, but it won't hurt to run it regardless of the platform
+  echo -e "\nFixing file permissions in final tob-api (django) image"
+  docker build -q \
+    -t 'django' \
+    -f '../../../credential-registry/server/Dockerfile' '../../../credential-registry/server'
+
 }
 
 buildImages() {


### PR DESCRIPTION
This addresses the `+x` permission issues that arise when running an `s2i` build under Windows.
I thought that, given the minimal cost this has on the overall build, we may as well run it regardless of the platform since we could potentially need to handle a bunch of different `$OSTYPE` environments other than `msys` (e.g.: cygwin or other shell interpreters).

Thoughts? 