### PR TITLE
Format code and organize imports

### DIFF
--- a/starter-kits/credential-registry/server/tob-api/api_v2/auth.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/auth.py
@@ -2,12 +2,10 @@ import logging
 import random
 from string import ascii_lowercase, digits
 
-from django.contrib.auth.models import Group, Permission
-from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import Group
 from rest_framework import permissions
 
 from api_v2.models.User import User
-
 
 ISSUERS_GROUP_NAME = "issuers"
 
@@ -28,9 +26,7 @@ def create_issuer_user(
     except User.DoesNotExist:
         logger.debug("Creating user for DID '{0}' ...".format(issuer_did))
         if not username:
-            username = generate_random_username(
-                length=12, prefix="issuer-", split=None
-            )
+            username = generate_random_username(length=12, prefix="issuer-", split=None)
         user = User.objects.create_user(
             username,
             email=email,
@@ -61,11 +57,7 @@ def get_issuers_group():
 
 
 def generate_random_username(
-    length=16,
-    chars=ascii_lowercase + digits,
-    split=4,
-    delimiter="-",
-    prefix="",
+    length=16, chars=ascii_lowercase + digits, split=4, delimiter="-", prefix=""
 ):
     username = "".join([random.choice(chars) for i in range(length)])
 

--- a/starter-kits/credential-registry/server/tob-api/api_v2/feedback.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/feedback.py
@@ -1,19 +1,19 @@
+import logging
+import os
 from email.header import Header
 from email.mime.text import MIMEText
 from email.utils import formataddr
-import logging
-import os
 from smtplib import SMTP, SMTPException
 
 LOGGER = logging.getLogger(__name__)
 
 
 def email_feedback(ip_addr, reply_name, reply_email, reason, comments):
-    server_addr = os.getenv('SMTP_SERVER_ADDRESS')
-    recip_email = os.getenv('FEEDBACK_TARGET_EMAIL')
-    app_url = os.getenv('APPLICATION_URL')
-    from_name = 'OrgBook BC'
-    from_email = 'no-reply@orgbook.gov.bc.ca'
+    server_addr = os.getenv("SMTP_SERVER_ADDRESS")
+    recip_email = os.getenv("FEEDBACK_TARGET_EMAIL")
+    app_url = os.getenv("APPLICATION_URL")
+    from_name = "OrgBook BC"
+    from_email = "no-reply@orgbook.gov.bc.ca"
 
     reason_map = {
         "incorrect": "Reporting incorrect information",
@@ -21,9 +21,9 @@ def email_feedback(ip_addr, reply_name, reply_email, reason, comments):
         "signup": "Looking to sign up my government organization",
         "developer": "Developer request",
     }
-    reason_text = reason_map.get(reason) or ''
+    reason_text = reason_map.get(reason) or ""
 
-    subject = 'OrgBook BC Feedback: {}'.format(reason_text)
+    subject = "OrgBook BC Feedback: {}".format(reason_text)
 
     LOGGER.info("Received feedback from %s <%s>", reply_name, reply_email)
     LOGGER.info("Feedback content: %s\n%s", subject, comments)
@@ -33,28 +33,28 @@ def email_feedback(ip_addr, reply_name, reply_email, reason, comments):
         return False
 
     if server_addr and recip_email:
-        body = ''
+        body = ""
         if app_url:
-            body = '{}Application URL: {}\n'.format(body, app_url)
+            body = "{}Application URL: {}\n".format(body, app_url)
         if ip_addr:
-            body = '{}IP address: {}\n'.format(body, ip_addr)
+            body = "{}IP address: {}\n".format(body, ip_addr)
         if reply_name:
-            body = '{}Name: {}\n'.format(body, reply_name)
+            body = "{}Name: {}\n".format(body, reply_name)
         if reply_email:
-            body = '{}Email: {}\n'.format(body, reply_email)
+            body = "{}Email: {}\n".format(body, reply_email)
         if reason_text:
-            body = '{}Contact reason: {}\n'.format(body, reason_text)
+            body = "{}Contact reason: {}\n".format(body, reason_text)
         if comments:
-            body = '{}Comments:\n{}\n'.format(body, comments)
-        msg = MIMEText(body, 'text')
+            body = "{}Comments:\n{}\n".format(body, comments)
+        msg = MIMEText(body, "text")
         recipients = ",".join(recip_email)
-        from_line = formataddr( (str(Header(from_name, 'utf-8')), from_email) )
-        reply_line = formataddr( (str(Header(reply_name, 'utf-8')), reply_email) )
-        msg['Subject'] = subject
-        msg['From'] = from_line
-        msg['Reply-To'] = reply_line
-        msg['To'] = recip_email
-        #LOGGER.info("encoded:\n%s", msg.as_string())
+        from_line = formataddr((str(Header(from_name, "utf-8")), from_email))
+        reply_line = formataddr((str(Header(reply_name, "utf-8")), reply_email))
+        msg["Subject"] = subject
+        msg["From"] = from_line
+        msg["Reply-To"] = reply_line
+        msg["To"] = recip_email
+        # LOGGER.info("encoded:\n%s", msg.as_string())
 
         with SMTP(server_addr) as smtp:
             try:

--- a/starter-kits/credential-registry/server/tob-api/api_v2/indices/Name.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/indices/Name.py
@@ -1,5 +1,5 @@
-from haystack import indexes
 from django.utils import timezone
+from haystack import indexes
 
 from api_v2.models.Name import Name as NameModel
 
@@ -18,6 +18,4 @@ class NameIndex(indexes.SearchIndex, indexes.Indexable):
         return NameModel
 
     def index_queryset(self, using=None):
-        return self.get_model().objects.filter(
-            create_timestamp__lte=timezone.now()
-        )
+        return self.get_model().objects.filter(create_timestamp__lte=timezone.now())

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Address.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Address.py
@@ -4,9 +4,11 @@ from .Auditable import Auditable
 
 
 class Address(Auditable):
-    reindex_related = ['credential']
+    reindex_related = ["credential"]
 
-    credential = models.ForeignKey("Credential", related_name="addresses", on_delete=models.CASCADE)
+    credential = models.ForeignKey(
+        "Credential", related_name="addresses", on_delete=models.CASCADE
+    )
     addressee = models.TextField(null=True)
     civic_address = models.TextField(null=True)
     city = models.TextField(null=True)
@@ -16,4 +18,4 @@ class Address(Auditable):
 
     class Meta:
         db_table = "address"
-        ordering = ('id',)
+        ordering = ("id",)

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Attribute.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Attribute.py
@@ -6,12 +6,14 @@ from .Auditable import Auditable
 class Attribute(Auditable):
     reindex_related = ["credential"]
 
-    credential = models.ForeignKey("Credential", related_name="attributes", on_delete=models.CASCADE)
-    type = models.TextField(db_index=True, default='text')
+    credential = models.ForeignKey(
+        "Credential", related_name="attributes", on_delete=models.CASCADE
+    )
+    type = models.TextField(db_index=True, default="text")
     format = models.TextField(null=True)
     value = models.TextField(null=True)
 
     class Meta:
         db_table = "attribute"
         unique_together = (("credential", "type"),)
-        ordering = ('id',)
+        ordering = ("id",)

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Auditable.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Auditable.py
@@ -2,13 +2,9 @@ from django.db import models
 
 
 class Auditable(models.Model):
-    create_timestamp = models.DateTimeField(
-        auto_now_add=True, blank=True, null=True
-    )
+    create_timestamp = models.DateTimeField(auto_now_add=True, blank=True, null=True)
 
-    update_timestamp = models.DateTimeField(
-        auto_now=True, blank=True, null=True
-    )
+    update_timestamp = models.DateTimeField(auto_now=True, blank=True, null=True)
 
     class Meta:
         abstract = True

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Claim.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Claim.py
@@ -1,15 +1,16 @@
 from django.db import models
 
 from .Auditable import Auditable
-
 from .Credential import Credential
 
 
 class Claim(Auditable):
-    credential = models.ForeignKey(Credential, related_name="claims", on_delete=models.CASCADE)
+    credential = models.ForeignKey(
+        Credential, related_name="claims", on_delete=models.CASCADE
+    )
     name = models.TextField(blank=True, null=True)
     value = models.TextField(blank=True, null=True)
 
     class Meta:
         db_table = "claim"
-        ordering = ('id',)
+        ordering = ("id",)

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Credential.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Credential.py
@@ -5,9 +5,15 @@ from .Auditable import Auditable
 
 
 class Credential(Auditable):
-    topic = models.ForeignKey("Topic", related_name="credentials", on_delete=models.CASCADE)
-    credential_set = models.ForeignKey("CredentialSet", related_name="credentials", null=True, on_delete=models.CASCADE)
-    credential_type = models.ForeignKey("CredentialType", related_name="credentials", on_delete=models.CASCADE)
+    topic = models.ForeignKey(
+        "Topic", related_name="credentials", on_delete=models.CASCADE
+    )
+    credential_set = models.ForeignKey(
+        "CredentialSet", related_name="credentials", null=True, on_delete=models.CASCADE
+    )
+    credential_type = models.ForeignKey(
+        "CredentialType", related_name="credentials", on_delete=models.CASCADE
+    )
     wallet_id = models.TextField(db_index=True)
     credential_def_id = models.TextField(db_index=True, null=True)
     cardinality_hash = models.TextField(db_index=True, null=True)
@@ -17,7 +23,9 @@ class Credential(Auditable):
     latest = models.BooleanField(db_index=True, default=False)
     revoked = models.BooleanField(db_index=True, default=False)
     revoked_date = models.DateTimeField(null=True)
-    revoked_by = models.ForeignKey("Credential", related_name="+", null=True, on_delete=models.SET_NULL)
+    revoked_by = models.ForeignKey(
+        "Credential", related_name="+", null=True, on_delete=models.SET_NULL
+    )
 
     # Topics related by this credential
     related_topics = models.ManyToManyField(
@@ -31,9 +39,10 @@ class Credential(Auditable):
 
     class Meta:
         db_table = "credential"
-        ordering = ('id',)
+        ordering = ("id",)
 
     _cache = None
+
     def _cached(self, key, val):
         cache = self._cache
         if cache is None:
@@ -46,7 +55,7 @@ class Credential(Auditable):
         names = self.all_names
         remote_name = None
         for name in names:
-            if name.type == 'entity_name_assumed':
+            if name.type == "entity_name_assumed":
                 return name
             else:
                 remote_name = name
@@ -57,7 +66,7 @@ class Credential(Auditable):
         has_assumed_name = False
         remote_name = None
         for name in names:
-            if name.type == 'entity_name_assumed':
+            if name.type == "entity_name_assumed":
                 has_assumed_name = True
             else:
                 remote_name = name
@@ -67,12 +76,12 @@ class Credential(Auditable):
     # used by solr document index
     @property
     def all_names(self):
-        return self._cached('names', self.names.all())
+        return self._cached("names", self.names.all())
 
     @property
     def all_categories(self):
-        return self._cached('categories', self.attributes.filter(format='category'))
+        return self._cached("categories", self.attributes.filter(format="category"))
 
     @property
     def all_attributes(self):
-        return self._cached('attributes', self.attributes.all())
+        return self._cached("attributes", self.attributes.all())

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/CredentialSet.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/CredentialSet.py
@@ -5,17 +5,21 @@ from .Auditable import Auditable
 
 
 class CredentialSet(Auditable):
-    credential_type = models.ForeignKey("CredentialType", related_name="credential_sets", on_delete=models.CASCADE)
+    credential_type = models.ForeignKey(
+        "CredentialType", related_name="credential_sets", on_delete=models.CASCADE
+    )
     cardinality_hash = models.TextField(db_index=True, null=True)
-    latest_credential = models.ForeignKey("Credential", related_name="+", null=True, on_delete=models.SET_NULL)
-    topic = models.ForeignKey("Topic", related_name="credential_sets", on_delete=models.CASCADE)
+    latest_credential = models.ForeignKey(
+        "Credential", related_name="+", null=True, on_delete=models.SET_NULL
+    )
+    topic = models.ForeignKey(
+        "Topic", related_name="credential_sets", on_delete=models.CASCADE
+    )
 
     first_effective_date = models.DateTimeField(null=True)
     last_effective_date = models.DateTimeField(null=True)
 
     class Meta:
         db_table = "credential_set"
-        unique_together = (
-            ("topic", "credential_type", "cardinality_hash"),
-        )
-        ordering = ('id',)
+        unique_together = (("topic", "credential_type", "cardinality_hash"),)
+        ordering = ("id",)

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/CredentialType.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/CredentialType.py
@@ -1,15 +1,18 @@
-from django.db import models
 from django.contrib.postgres import fields as contrib
+from django.db import models
 
 from .Auditable import Auditable
-
 from .Issuer import Issuer
 from .Schema import Schema
 
 
 class CredentialType(Auditable):
-    schema = models.ForeignKey(Schema, related_name="credential_types", on_delete=models.CASCADE)
-    issuer = models.ForeignKey(Issuer, related_name="credential_types", on_delete=models.CASCADE)
+    schema = models.ForeignKey(
+        Schema, related_name="credential_types", on_delete=models.CASCADE
+    )
+    issuer = models.ForeignKey(
+        Issuer, related_name="credential_types", on_delete=models.CASCADE
+    )
     description = models.TextField(blank=True, null=True)
     processor_config = contrib.JSONField(blank=True, null=True)
     credential_def_id = models.TextField(db_index=True, null=True)
@@ -24,7 +27,7 @@ class CredentialType(Auditable):
     class Meta:
         db_table = "credential_type"
         unique_together = (("schema", "issuer"),)
-        ordering = ('id',)
+        ordering = ("id",)
 
     def get_has_logo(self):
         return bool(self.logo_b64 or (self.issuer and self.issuer.logo_b64))

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Issuer.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Issuer.py
@@ -14,7 +14,7 @@ class Issuer(Auditable):
 
     class Meta:
         db_table = "issuer"
-        ordering = ('id',)
+        ordering = ("id",)
 
     def get_has_logo(self):
         return bool(self.logo_b64)

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Name.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Name.py
@@ -1,18 +1,19 @@
 from django.db import models
 
 from .Auditable import Auditable
-
 from .Credential import Credential
 
 
 class Name(Auditable):
-    reindex_related = ['credential']
+    reindex_related = ["credential"]
 
-    credential = models.ForeignKey(Credential, related_name="names", on_delete=models.CASCADE)
+    credential = models.ForeignKey(
+        Credential, related_name="names", on_delete=models.CASCADE
+    )
     text = models.TextField(null=True)
     language = models.TextField(null=True)
     type = models.TextField(null=True)
 
     class Meta:
         db_table = "name"
-        ordering = ('id',)
+        ordering = ("id",)

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Schema.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Schema.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils import timezone
 
 from .Auditable import Auditable
 
@@ -12,4 +11,4 @@ class Schema(Auditable):
     class Meta:
         db_table = "schema"
         unique_together = (("name", "version", "origin_did"),)
-        ordering = ('id',)
+        ordering = ("id",)

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Topic.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Topic.py
@@ -1,12 +1,8 @@
 from django.db import models
 
-from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
-
-from .Auditable import Auditable
-
 from .Address import Address
 from .Attribute import Attribute
+from .Auditable import Auditable
 from .Name import Name
 
 
@@ -29,7 +25,7 @@ class Topic(Auditable):
     class Meta:
         db_table = "topic"
         unique_together = (("source_id", "type"),)
-        ordering = ('id',)
+        ordering = ("id",)
 
     def save(self, *args, **kwargs):
         """
@@ -41,8 +37,11 @@ class Topic(Auditable):
 
     def get_active_credential_ids(self):
         if self._active_cred_ids is None:
-            self._active_cred_ids = set(self.credentials.filter(latest=True, revoked=False)\
-                .only('id', 'topic_id').values_list('id', flat=True))
+            self._active_cred_ids = set(
+                self.credentials.filter(latest=True, revoked=False)
+                .only("id", "topic_id")
+                .values_list("id", flat=True)
+            )
         return self._active_cred_ids
 
     def get_active_addresses(self):
@@ -54,7 +53,10 @@ class Topic(Auditable):
     def get_active_attributes(self):
         creds = self.get_active_credential_ids()
         if creds:
-            return Attribute.objects.filter(credential_id__in=creds, credential__credential_type__description='Registration')
+            return Attribute.objects.filter(
+                credential_id__in=creds,
+                credential__credential_type__description="Registration",
+            )
         return []
 
     def get_active_names(self):
@@ -69,7 +71,7 @@ class Topic(Auditable):
             names = Name.objects.filter(credential_id__in=creds)
             remote_name = None
             for name in names:
-                if name.type == 'entity_name_assumed':
+                if name.type == "entity_name_assumed":
                     return name
                 else:
                     remote_name = name
@@ -83,7 +85,7 @@ class Topic(Auditable):
             has_assumed_name = False
             remote_name = None
             for name in names:
-                if name.type == 'entity_name_assumed':
+                if name.type == "entity_name_assumed":
                     has_assumed_name = True
                 else:
                     remote_name = name
@@ -93,10 +95,10 @@ class Topic(Auditable):
 
     def get_active_related_to(self):
         return self.related_to.filter(
-            from_rels__credential__latest=True,
-            from_rels__credential__revoked=False)
+            from_rels__credential__latest=True, from_rels__credential__revoked=False
+        )
 
     def get_active_related_from(self):
         return self.related_from.filter(
-            to_rels__credential__latest=True,
-            to_rels__credential__revoked=False)
+            to_rels__credential__latest=True, to_rels__credential__revoked=False
+        )

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/TopicRelationship.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/TopicRelationship.py
@@ -1,19 +1,21 @@
 from django.db import models
-from django.utils import timezone
 
 from .Auditable import Auditable
-
 from .Topic import Topic
 
 
 class TopicRelationship(Auditable):
-    credential = models.ForeignKey("Credential", related_name="topic_rels", on_delete=models.CASCADE)
+    credential = models.ForeignKey(
+        "Credential", related_name="topic_rels", on_delete=models.CASCADE
+    )
     topic = models.ForeignKey(Topic, related_name="from_rels", on_delete=models.CASCADE)
-    related_topic = models.ForeignKey(Topic, related_name="to_rels", on_delete=models.CASCADE)
+    related_topic = models.ForeignKey(
+        Topic, related_name="to_rels", on_delete=models.CASCADE
+    )
 
     class Meta:
         db_table = "topic_relationship"
-        ordering = ('id',)
+        ordering = ("id",)
 
     @property
     def credential_attributes(self):

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/User.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/User.py
@@ -1,5 +1,5 @@
-from django.db import models
 from django.contrib.auth.models import AbstractUser
+from django.db import models
 
 
 class User(AbstractUser):

--- a/starter-kits/credential-registry/server/tob-api/api_v2/search/filters.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/search/filters.py
@@ -3,15 +3,8 @@ import logging
 import operator
 
 from django.conf import settings
-from drf_haystack.query import (
-    BaseQueryBuilder,
-    FacetQueryBuilder,
-    FilterQueryBuilder,
-)
-from drf_haystack.filters import (
-    HaystackFilter,
-    HaystackFacetFilter,
-)
+from drf_haystack.filters import HaystackFacetFilter, HaystackFilter
+from drf_haystack.query import BaseQueryBuilder, FacetQueryBuilder
 from haystack.inputs import Clean, Exact, Raw
 
 LOGGER = logging.getLogger(__name__)
@@ -25,49 +18,51 @@ class Proximate(Clean):
     """
     Prepare a filter clause matching one or more words, adjusting score according to word proximity
     """
-    input_type_name = 'contains'
-    post_process = False # don't put AND between terms
+
+    input_type_name = "contains"
+    post_process = False  # don't put AND between terms
 
     def query_words(self, *parts):
         skip = settings.SEARCH_SKIP_WORDS or ()
-        word_len = self.kwargs.get('wordlen', 4)
+        word_len = self.kwargs.get("wordlen", 4)
         for part in parts:
             clean = part.strip()
-            if len(clean.strip('_-,.;\'"')) >= word_len and clean.lower() not in skip:
+            if len(clean.strip("_-,.;'\"")) >= word_len and clean.lower() not in skip:
                 yield clean
 
     def prepare(self, query_obj):
         # clean input
         query_string = super(Proximate, self).prepare(query_obj)
-        if query_string is not '':
+        if query_string is not "":
             # match phrase with minimal word movements
-            proximity = self.kwargs.get('proximity', 5)
-            parts = query_string.split(' ')
+            proximity = self.kwargs.get("proximity", 5)
+            parts = query_string.split(" ")
             if len(parts) > 1:
                 output = '"{}"~{}'.format(query_string, proximity)
             else:
                 output = parts[0]
-            if 'boost' in self.kwargs:
-                output = '{}^{}'.format(output, self.kwargs['boost'])
+            if "boost" in self.kwargs:
+                output = "{}^{}".format(output, self.kwargs["boost"])
 
             # increase score for any individual term
-            if self.kwargs.get('any') and len(parts) > 1:
+            if self.kwargs.get("any") and len(parts) > 1:
                 words = list(self.query_words(*parts))
                 if words:
-                    output = ' OR '.join([output, *words])
+                    output = " OR ".join([output, *words])
         else:
             output = query_string
         return output
 
 
 class AutocompleteFilterBuilder(BaseQueryBuilder):
-    query_param = 'q'
+    query_param = "q"
 
     def build_name_query(self, term):
         SQ = self.view.query_object
         match_any = not settings.SEARCH_TERMS_EXCLUSIVE
-        return SQ(name_suggest=Proximate(term)) \
-               | SQ(name_precise=Proximate(term, boost=10, any=match_any))
+        return SQ(name_suggest=Proximate(term)) | SQ(
+            name_precise=Proximate(term, boost=10, any=match_any)
+        )
 
     def build_query(self, **filters):
         inclusions = []
@@ -85,11 +80,12 @@ class AutocompleteFilter(CustomFilter):
     """
     Apply name autocomplete filter to credential search
     """
+
     query_builder_class = AutocompleteFilterBuilder
 
 
 class CategoryFilterBuilder(BaseQueryBuilder):
-    query_param = 'category'
+    query_param = "category"
 
     def build_query(self, **filters):
         inclusions = {}
@@ -99,22 +95,22 @@ class CategoryFilterBuilder(BaseQueryBuilder):
             category = None
             by_value = False
             negate = False
-            if ':' in qname:
-                parts = qname.split(':', 1)
+            if ":" in qname:
+                parts = qname.split(":", 1)
                 if parts[0] == self.query_param:
                     category = parts[1]
-                    if '__' in category:
-                        category, oper = category.split('__', 1)
-                        if oper == 'not':
+                    if "__" in category:
+                        category, oper = category.split("__", 1)
+                        if oper == "not":
                             negate = True
-                        elif oper != 'exact':
+                        elif oper != "exact":
                             continue
             else:
-                if '__' in qname:
-                    qname, oper = qname.split('__', 1)
-                    if oper == 'not':
+                if "__" in qname:
+                    qname, oper = qname.split("__", 1)
+                    if oper == "not":
                         negate = True
-                    elif oper != 'exact':
+                    elif oper != "exact":
                         continue
                 if qname == self.query_param:
                     by_value = True
@@ -125,17 +121,21 @@ class CategoryFilterBuilder(BaseQueryBuilder):
                 if not qv:
                     continue
                 if by_value:
-                    if '::' not in qv:
+                    if "::" not in qv:
                         continue
-                    category, qv = qv.split('::', 1)
-                filt = Exact('{}::{}'.format(category, qv))
+                    category, qv = qv.split("::", 1)
+                filt = Exact("{}::{}".format(category, qv))
                 sq_filt = SQ(**{self.query_param: filt})
                 if category in target:
                     target[category] = target[category] | sq_filt
                 else:
                     target[category] = sq_filt
-        inclusions = functools.reduce(operator.and_, inclusions.values()) if inclusions else None
-        exclusions = functools.reduce(operator.and_, exclusions.values()) if exclusions else None
+        inclusions = (
+            functools.reduce(operator.and_, inclusions.values()) if inclusions else None
+        )
+        exclusions = (
+            functools.reduce(operator.and_, exclusions.values()) if exclusions else None
+        )
         return inclusions, exclusions
 
 
@@ -143,6 +143,7 @@ class CategoryFilter(CustomFilter):
     """
     Apply category filters to credential search
     """
+
     query_builder_class = CategoryFilterBuilder
 
 
@@ -150,13 +151,14 @@ class CredNameFilterBuilder(AutocompleteFilterBuilder):
     """
     Augment autocomplete filter with matching on the related topic source ID
     """
-    query_param = 'name'
+
+    query_param = "name"
 
     def build_name_query(self, term):
         SQ = self.view.query_object
         filter = super(CredNameFilterBuilder, self).build_name_query(term)
-        if term and ' ' not in term:
-            filter = filter | (SQ(source_id=Exact(term)) & SQ(name=Raw('*')))
+        if term and " " not in term:
+            filter = filter | (SQ(source_id=Exact(term)) & SQ(name=Raw("*")))
         return filter
 
 
@@ -164,6 +166,7 @@ class CredNameFilter(AutocompleteFilter):
     """
     Apply autocomplete filter
     """
+
     query_builder_class = CredNameFilterBuilder
 
 
@@ -171,19 +174,24 @@ class ExactFilterBuilder(BaseQueryBuilder):
     """
     Perform exact matching on specified fields
     """
+
     def build_query(self, **filters):
         inclusions = {}
         exclusions = None
         SQ = self.view.query_object
-        exact_fields = getattr(self.view.serializer_class.Meta, 'exact_fields', [])
+        exact_fields = getattr(self.view.serializer_class.Meta, "exact_fields", [])
         for qname, qvals in filters.items():
             if qname not in exact_fields:
                 continue
             for qval in qvals:
                 if qval:
                     filt = SQ(**{qname: Exact(qval)})
-                    inclusions[qname] = (filt | inclusions[qname]) if qname in inclusions else filt
-        inclusions = functools.reduce(operator.and_, inclusions.values()) if inclusions else None
+                    inclusions[qname] = (
+                        (filt | inclusions[qname]) if qname in inclusions else filt
+                    )
+        inclusions = (
+            functools.reduce(operator.and_, inclusions.values()) if inclusions else None
+        )
         return inclusions, exclusions
 
 
@@ -191,6 +199,7 @@ class ExactFilter(CustomFilter):
     """
     Apply exact-match filters
     """
+
     query_builder_class = ExactFilterBuilder
 
 
@@ -209,19 +218,21 @@ class StatusFilterBuilder(BaseQueryBuilder):
         inclusions = {}
         exclusions = None
         SQ = self.view.query_object
-        status_fields = getattr(self.view.serializer_class.Meta, 'status_fields', {})
+        status_fields = getattr(self.view.serializer_class.Meta, "status_fields", {})
         for qname, qval in status_fields.items():
-            if qval and qval != 'any':
+            if qval and qval != "any":
                 inclusions[qname] = SQ(**{qname: Exact(qval)})
         for qname, qvals in filters.items():
             if qname not in status_fields:
                 continue
             for qval in qvals:
-                if qval and qval != 'any':
+                if qval and qval != "any":
                     inclusions[qname] = SQ(**{qname: Exact(qval)})
                 elif qname in inclusions:
                     del inclusions[qname]
-        inclusions = functools.reduce(operator.and_, inclusions.values()) if inclusions else None
+        inclusions = (
+            functools.reduce(operator.and_, inclusions.values()) if inclusions else None
+        )
         return inclusions, exclusions
 
 
@@ -229,4 +240,5 @@ class StatusFilter(CustomFilter):
     """
     Apply boolean filter flags
     """
+
     query_builder_class = StatusFilterBuilder

--- a/starter-kits/credential-registry/server/tob-api/api_v2/search/index.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/search/index.py
@@ -39,7 +39,9 @@ class TxnAwareSearchIndex(indexes.SearchIndex):
             if self._backend_queue:
                 self._backend_queue.add(self.__class__, using, [instance])
             else:
-                super(TxnAwareSearchIndex, self).update_object(instance, using, **kwargs)
+                super(TxnAwareSearchIndex, self).update_object(
+                    instance, using, **kwargs
+                )
 
     def remove_object(self, instance, using=None, **kwargs):
         conn = transaction.get_connection()
@@ -59,7 +61,9 @@ class TxnAwareSearchIndex(indexes.SearchIndex):
             if self._backend_queue:
                 self._backend_queue.delete(self.__class__, using, [instance])
             else:
-                super(TxnAwareSearchIndex, self).remove_object(instance, using, **kwargs)
+                super(TxnAwareSearchIndex, self).remove_object(
+                    instance, using, **kwargs
+                )
 
     def transaction_committed(self):
         conn = transaction.get_connection()
@@ -70,26 +74,42 @@ class TxnAwareSearchIndex(indexes.SearchIndex):
         else:
             for using, instances in self._transaction_removed.items():
                 if instances:
-                    LOGGER.debug("Committing %d deferred Solr delete(s) after transaction.", len(instances))
+                    LOGGER.debug(
+                        "Committing %d deferred Solr delete(s) after transaction.",
+                        len(instances),
+                    )
                     if self._backend_queue:
-                        self._backend_queue.delete(self.__class__, using, list(instances.values()))
+                        self._backend_queue.delete(
+                            self.__class__, using, list(instances.values())
+                        )
                     else:
                         backend = self.get_backend(using)
                         if backend is not None:
                             for instance in instances.values():
                                 backend.remove(instance)
                         else:
-                            LOGGER.error("Failed to get backend.  Unable to commit %d deferred Solr delete(s) after transaction.", len(instances))
+                            LOGGER.error(
+                                "Failed to get backend.  Unable to commit %d deferred Solr delete(s) after transaction.",
+                                len(instances),
+                            )
 
             for using, instances in self._transaction_added.items():
                 if instances:
-                    LOGGER.debug("Committing %d deferred Solr update(s) after transaction", len(instances))
+                    LOGGER.debug(
+                        "Committing %d deferred Solr update(s) after transaction",
+                        len(instances),
+                    )
                     if self._backend_queue:
-                        self._backend_queue.add(self.__class__, using, list(instances.values()))
+                        self._backend_queue.add(
+                            self.__class__, using, list(instances.values())
+                        )
                     else:
                         backend = self.get_backend(using)
                         if backend is not None:
                             backend.update(self, instances.values())
                         else:
-                            LOGGER.error("Failed to get backend.  Unable to commit %d deferred Solr update(s) after transaction.", len(instances))
+                            LOGGER.error(
+                                "Failed to get backend.  Unable to commit %d deferred Solr update(s) after transaction.",
+                                len(instances),
+                            )
             self.reset()

--- a/starter-kits/credential-registry/server/tob-api/api_v2/search_test.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/search_test.py
@@ -1,49 +1,22 @@
 from django.db import transaction
-from api_v2.models import Credential, Name
+
+from api_v2.models import Credential
 
 data = [
-    {
-        "name": "Test Corp",
-    },
-    {
-        "name": "Testing Corp",
-    },
-    {
-        "name": "Test, Corp",
-    },
-    {
-        "name": "Tested, Corp",
-    },
-    {
-        "name": "Retest Corp",
-    },
-    {
-        "name": "Re-test Corp",
-    },
-    {
-        "name": "Test-Corp",
-    },
-    {
-        "name": "Corp Test",
-    },
-    {
-        "name": "Corp, Test",
-    },
-    {
-        "name": "Test.Corp",
-    },
-    {
-        "name": "Test,Corp",
-    },
-    {
-        "name": "Test+Corp",
-    },
-    {
-        "name": "Te-st Corp",
-    },
-    {
-        "name": "Other Corp",
-    },
+    {"name": "Test Corp"},
+    {"name": "Testing Corp"},
+    {"name": "Test, Corp"},
+    {"name": "Tested, Corp"},
+    {"name": "Retest Corp"},
+    {"name": "Re-test Corp"},
+    {"name": "Test-Corp"},
+    {"name": "Corp Test"},
+    {"name": "Corp, Test"},
+    {"name": "Test.Corp"},
+    {"name": "Test,Corp"},
+    {"name": "Test+Corp"},
+    {"name": "Te-st Corp"},
+    {"name": "Other Corp"},
 ]
 
 
@@ -52,6 +25,8 @@ def init_db():
     for row in data:
         # use transaction so that the name is added before the credential is indexed
         with transaction.atomic():
-            cred = Credential.objects.create(credential_type_id=1, topic_id=1, latest=True)
+            cred = Credential.objects.create(
+                credential_type_id=1, topic_id=1, latest=True
+            )
             # cred.save()
             name = cred.names.create(text=row["name"])

--- a/starter-kits/credential-registry/server/tob-api/api_v2/serializers/rest.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/serializers/rest.py
@@ -1,16 +1,21 @@
-from rest_framework.serializers import BooleanField, ModelSerializer, SerializerMethodField
-from api_v2.models.Issuer import Issuer
-from api_v2.models.Schema import Schema
-from api_v2.models.CredentialType import CredentialType
-from api_v2.models.Topic import Topic
-from api_v2.models.TopicRelationship import TopicRelationship
+from rest_framework.serializers import (
+    BooleanField,
+    ModelSerializer,
+    SerializerMethodField,
+)
+
+from api_v2 import utils
+from api_v2.models.Address import Address
+from api_v2.models.Attribute import Attribute
+from api_v2.models.Claim import Claim
 from api_v2.models.Credential import Credential
 from api_v2.models.CredentialSet import CredentialSet
-from api_v2.models.Address import Address
-from api_v2.models.Claim import Claim
+from api_v2.models.CredentialType import CredentialType
+from api_v2.models.Issuer import Issuer
 from api_v2.models.Name import Name
-from api_v2.models.Attribute import Attribute
-from api_v2 import utils
+from api_v2.models.Schema import Schema
+from api_v2.models.Topic import Topic
+from api_v2.models.TopicRelationship import TopicRelationship
 
 
 class IssuerSerializer(ModelSerializer):
@@ -18,9 +23,7 @@ class IssuerSerializer(ModelSerializer):
 
     class Meta:
         model = Issuer
-        exclude = (
-            "logo_b64",
-        )
+        exclude = ("logo_b64",)
 
 
 class SchemaSerializer(ModelSerializer):
@@ -33,9 +36,13 @@ class CredentialSetSerializer(ModelSerializer):
     class Meta:
         model = CredentialSet
         fields = (
-            "id", "create_timestamp", "update_timestamp",
-            "latest_credential_id", "topic_id",
-            "first_effective_date", "last_effective_date",
+            "id",
+            "create_timestamp",
+            "update_timestamp",
+            "latest_credential_id",
+            "topic_id",
+            "first_effective_date",
+            "last_effective_date",
         )
 
 
@@ -59,19 +66,27 @@ class CredentialTypeSerializer(ModelSerializer):
 class TopicSerializer(ModelSerializer):
     class Meta:
         model = Topic
-        fields = list(utils.fetch_custom_settings('serializers', 'Topic', 'includeFields'))
+        fields = list(
+            utils.fetch_custom_settings("serializers", "Topic", "includeFields")
+        )
 
 
 class TopicRelationshipSerializer(ModelSerializer):
     class Meta:
         model = TopicRelationship
-        fields = list(utils.fetch_custom_settings('serializers', 'TopicRelationship', 'includeFields'))
+        fields = list(
+            utils.fetch_custom_settings(
+                "serializers", "TopicRelationship", "includeFields"
+            )
+        )
 
 
 class AddressSerializer(ModelSerializer):
     class Meta:
         model = Address
-        fields = list(utils.fetch_custom_settings('serializers', 'Address', 'includeFields'))
+        fields = list(
+            utils.fetch_custom_settings("serializers", "Address", "includeFields")
+        )
 
 
 class ClaimSerializer(ModelSerializer):
@@ -96,15 +111,29 @@ class CredentialAttributeSerializer(AttributeSerializer):
     class Meta(AttributeSerializer.Meta):
         fields = ("id", "type", "format", "value", "credential_id")
 
+
 class CredentialSerializer(ModelSerializer):
-    attributes = CredentialAttributeSerializer(source='all_attributes', many=True)
+    attributes = CredentialAttributeSerializer(source="all_attributes", many=True)
+
     class Meta:
         model = Credential
         fields = (
-            "topic","credential_set","credential_type","wallet_id","credential_def_id","cardinality_hash",
-            "effective_date","inactive","latest","revoked","revoked_date","revoked_by","related_topics",
+            "topic",
+            "credential_set",
+            "credential_type",
+            "wallet_id",
+            "credential_def_id",
+            "cardinality_hash",
+            "effective_date",
+            "inactive",
+            "latest",
+            "revoked",
+            "revoked_date",
+            "revoked_by",
+            "related_topics",
             "attributes",
         )
+
 
 class CredentialAddressSerializer(AddressSerializer):
     class Meta(AddressSerializer.Meta):
@@ -112,39 +141,56 @@ class CredentialAddressSerializer(AddressSerializer):
             {*AddressSerializer.Meta.fields, "credential_id"} - {"credential"}
         )
 
+
 class CredentialNameSerializer(NameSerializer):
     class Meta(NameSerializer.Meta):
-        fields = ("id", "text", "language", "credential_id", "type",)
+        fields = ("id", "text", "language", "credential_id", "type")
+
 
 class CredentialTopicSerializer(TopicSerializer):
     class Meta(TopicSerializer.Meta):
-        fields = (
-            "id", "create_timestamp", "update_timestamp",
-            "source_id", "type",
-        )
+        fields = ("id", "create_timestamp", "update_timestamp", "source_id", "type")
+
 
 class CredentialNamedTopicSerializer(CredentialTopicSerializer):
-    names = CredentialNameSerializer(source='get_active_names', many=True)
-    local_name = CredentialNameSerializer(source='get_local_name')
-    remote_name = CredentialNameSerializer(source='get_remote_name')
+    names = CredentialNameSerializer(source="get_active_names", many=True)
+    local_name = CredentialNameSerializer(source="get_local_name")
+    remote_name = CredentialNameSerializer(source="get_remote_name")
 
     class Meta(CredentialTopicSerializer.Meta):
-        fields = CredentialTopicSerializer.Meta.fields + ("names","local_name","remote_name",)
+        fields = CredentialTopicSerializer.Meta.fields + (
+            "names",
+            "local_name",
+            "remote_name",
+        )
+
 
 class TopicAttributeSerializer(AttributeSerializer):
     credential_type_id = SerializerMethodField()
+
     class Meta(CredentialAttributeSerializer.Meta):
-        fields = ("id", "type", "format", "value", "credential_id", "credential_type_id")
+        fields = (
+            "id",
+            "type",
+            "format",
+            "value",
+            "credential_id",
+            "credential_type_id",
+        )
 
     def get_credential_type_id(self, obj):
         return obj.credential.credential_type_id
 
+
 class CredentialTopicExtSerializer(CredentialNamedTopicSerializer):
-    addresses = CredentialAddressSerializer(source='get_active_addresses', many=True)
-    attributes = TopicAttributeSerializer(source='get_active_attributes', many=True)
+    addresses = CredentialAddressSerializer(source="get_active_addresses", many=True)
+    attributes = TopicAttributeSerializer(source="get_active_attributes", many=True)
 
     class Meta(CredentialNamedTopicSerializer.Meta):
-        fields = CredentialNamedTopicSerializer.Meta.fields + ("addresses", "attributes")
+        fields = CredentialNamedTopicSerializer.Meta.fields + (
+            "addresses",
+            "attributes",
+        )
 
 
 class CredentialExtSerializer(CredentialSerializer):
@@ -152,8 +198,8 @@ class CredentialExtSerializer(CredentialSerializer):
     attributes = CredentialAttributeSerializer(many=True)
     credential_type = CredentialTypeSerializer()
     names = CredentialNameSerializer(many=True)
-    local_name = CredentialNameSerializer(source='get_local_name')
-    remote_name = CredentialNameSerializer(source='get_remote_name')
+    local_name = CredentialNameSerializer(source="get_local_name")
+    remote_name = CredentialNameSerializer(source="get_remote_name")
     topic = CredentialTopicExtSerializer()
     related_topics = CredentialNamedTopicSerializer(many=True)
 

--- a/starter-kits/credential-registry/server/tob-api/api_v2/setup.cfg
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+# https://github.com/ambv/black#line-length
+max-line-length = 88
+exclude =
+    */tests/**
+    */__init__.py
+ignore = D202, W503

--- a/starter-kits/credential-registry/server/tob-api/api_v2/swagger.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/swagger.py
@@ -1,11 +1,10 @@
 import logging
+
+from drf_yasg import renderers
 from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.schemas import SchemaGenerator
 from rest_framework.views import APIView
-
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
 
 LOGGER = logging.getLogger(__name__)
 
@@ -14,17 +13,16 @@ class SwaggerSchemaView(APIView):
     """
     Utility class for rendering swagger documentation
     """
+
     permission_classes = (permissions.AllowAny,)
     renderer_classes = [renderers.OpenAPIRenderer, renderers.SwaggerUIRenderer]
     schema = None
 
     def get(self, request):
-        params = {
-            "urlconf": "api_v2.urls",
-        }
+        params = {"urlconf": "api_v2.urls"}
         if "HTTP_X_FORWARDED_HOST" in request.META:
             # forwarding via tob-web
-            #params["url"] = "{}://{}/api/".format(
+            # params["url"] = "{}://{}/api/".format(
             #    request.META.get("HTTP_X_FORWARDED_PROTO", "http"),
             #    request.META["HTTP_X_FORWARDED_HOST"])
             params["url"] = "/api/"

--- a/starter-kits/credential-registry/server/tob-api/api_v2/urls.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/urls.py
@@ -1,8 +1,8 @@
 from django.conf import settings
-from django.urls import include, path
+from django.urls import path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
-from rest_framework.permissions import AllowAny, DjangoModelPermissionsOrAnonReadOnly
+from rest_framework.permissions import AllowAny
 from rest_framework.routers import SimpleRouter
 from rest_framework.urlpatterns import format_suffix_patterns
 

--- a/starter-kits/credential-registry/server/tob-api/api_v2/utils.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/utils.py
@@ -1,15 +1,12 @@
-
 """
 A collection of utility classes for TOB
 """
 
-from datetime import datetime, timedelta
 import logging
-import os
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.db import connection
-
 from haystack.query import SearchQuerySet
 from pysolr import SolrError
 
@@ -49,12 +46,14 @@ def model_counts(model_cls, cursor=None, optimize=None):
             close = True
         cursor.execute(
             "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname=%s",
-            [model_cls._meta.db_table])
+            [model_cls._meta.db_table],
+        )
         row = cursor.fetchone()
     finally:
         if close:
             cursor.close()
     return row[0]
+
 
 def record_count(model_cls, cursor=None):
     close = False
@@ -62,14 +61,15 @@ def record_count(model_cls, cursor=None):
         if not cursor:
             cursor = connection.cursor()
             close = True
-        query = 'SELECT count(*) FROM %s' % model_cls._meta.db_table
+        query = "SELECT count(*) FROM %s" % model_cls._meta.db_table
         cursor.execute(query)
         row = cursor.fetchone()
     finally:
         if close:
             cursor.close()
     return row[0]
-    
+
+
 def solr_counts():
     total_q = SearchQuerySet()
     latest_q = total_q.filter(latest=True)

--- a/starter-kits/credential-registry/server/tob-api/api_v2/views/auditable.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/views/auditable.py
@@ -1,5 +1,5 @@
-from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.response import Response
 
 
 class AuditableMixin(object):
@@ -21,9 +21,7 @@ class AuditableMixin(object):
 
         response = objs[0] if len(objs) == 1 else objs
         headers = self.get_success_headers(response)
-        return Response(
-            response, status=status.HTTP_201_CREATED, headers=headers
-        )
+        return Response(response, status=status.HTTP_201_CREATED, headers=headers)
 
     def perform_create(self, serializer, request):
         instance = serializer.save()
@@ -33,9 +31,7 @@ class AuditableMixin(object):
         instance = self.get_object()
         http_sm_user = request.META.get("HTTP_SM_USER")
         request.data.update({"UPDATE_USER": http_sm_user})
-        serializer = self.get_serializer(
-            instance, data=request.data, partial=partial
-        )
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
 

--- a/starter-kits/credential-registry/server/tob-api/api_v2/views/misc.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/views/misc.py
@@ -6,12 +6,8 @@ from django.http import JsonResponse
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import permissions
-from rest_framework.decorators import (
-    api_view,
-    authentication_classes,
-    parser_classes,
-    permission_classes,
-)
+from rest_framework.decorators import (api_view, authentication_classes,
+                                       parser_classes, permission_classes)
 from rest_framework.parsers import FormParser
 
 from api_v2.feedback import email_feedback

--- a/starter-kits/credential-registry/server/tob-api/api_v2/views/rest.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/views/rest.py
@@ -1,55 +1,42 @@
 import base64
 
 from django.db.models import Q
-from django.http import HttpResponse, Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
-
-from rest_framework.exceptions import NotFound
-from rest_framework.decorators import detail_route, list_route
-from rest_framework.viewsets import ReadOnlyModelViewSet, ViewSet
-from rest_framework.response import Response
-
-from api_v2.serializers.rest import (
-    IssuerSerializer,
-    SchemaSerializer,
-    CredentialTypeSerializer,
-    TopicSerializer,
-    TopicRelationshipSerializer,
-    CredentialSerializer,
-    ExpandedCredentialSerializer,
-    ExpandedCredentialSetSerializer,
-    AddressSerializer,
-    AttributeSerializer,
-    NameSerializer,
-    CredentialTopicExtSerializer,
-)
-
-from rest_framework.serializers import SerializerMethodField
-
-from drf_yasg.utils import swagger_auto_schema
-
 from django_filters import rest_framework as filters
-
-from api_v2.serializers.search import CustomTopicSerializer, CustomTopicRelationshipSerializer
-
-from api_v2.models.Issuer import Issuer
-from api_v2.models.Schema import Schema
-from api_v2.models.CredentialType import CredentialType
-from api_v2.models.Topic import Topic
-from api_v2.models.TopicRelationship import TopicRelationship
-from api_v2.models.Credential import Credential
-from api_v2.models.Address import Address
-from api_v2.models.Attribute import Attribute
-from api_v2.models.Name import Name
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.decorators import detail_route, list_route
+from rest_framework.response import Response
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from api_v2 import utils
+from api_v2.models.Address import Address
+from api_v2.models.Attribute import Attribute
+from api_v2.models.Credential import Credential
+from api_v2.models.CredentialType import CredentialType
+from api_v2.models.Issuer import Issuer
+from api_v2.models.Name import Name
+from api_v2.models.Schema import Schema
+from api_v2.models.Topic import Topic
+from api_v2.models.TopicRelationship import TopicRelationship
+from api_v2.serializers.rest import (AddressSerializer, AttributeSerializer,
+                                     CredentialSerializer,
+                                     CredentialTopicExtSerializer,
+                                     CredentialTypeSerializer,
+                                     ExpandedCredentialSerializer,
+                                     ExpandedCredentialSetSerializer,
+                                     IssuerSerializer, NameSerializer,
+                                     SchemaSerializer,
+                                     TopicRelationshipSerializer,
+                                     TopicSerializer)
+from api_v2.serializers.search import CustomTopicSerializer
 
 
 class IssuerViewSet(ReadOnlyModelViewSet):
     serializer_class = IssuerSerializer
     queryset = Issuer.objects.all()
 
-    @swagger_auto_schema(method='get')
+    @swagger_auto_schema(method="get")
     @detail_route(url_path="credentialtype", methods=["get"])
     def list_credential_types(self, request, pk=None):
         item = self.get_object()
@@ -57,7 +44,7 @@ class IssuerViewSet(ReadOnlyModelViewSet):
         serializer = CredentialTypeSerializer(queryset, many=True)
         return Response(serializer.data)
 
-    @swagger_auto_schema(method='get')
+    @swagger_auto_schema(method="get")
     @detail_route(url_path="logo", methods=["get"])
     def fetch_logo(self, request, pk=None):
         issuer = get_object_or_404(self.queryset, pk=pk)
@@ -74,7 +61,7 @@ class SchemaViewSet(ReadOnlyModelViewSet):
     serializer_class = SchemaSerializer
     queryset = Schema.objects.all()
     filter_backends = (filters.DjangoFilterBackend,)
-    filterset_fields = ('id', 'name', 'version', 'origin_did',)
+    filterset_fields = ("id", "name", "version", "origin_did")
 
 
 class CredentialTypeViewSet(ReadOnlyModelViewSet):
@@ -258,6 +245,8 @@ class NameViewSet(ReadOnlyModelViewSet):
 # Add environment specific endpoints
 try:
     utils.apply_custom_methods(TopicViewSet, "views", "TopicViewSet", "includeMethods")
-    utils.apply_custom_methods(TopicRelationshipViewSet, "views", "TopicRelationshipViewSet", "includeMethods")
+    utils.apply_custom_methods(
+        TopicRelationshipViewSet, "views", "TopicRelationshipViewSet", "includeMethods"
+    )
 except:
     pass

--- a/starter-kits/credential-registry/server/tob-api/icat_cbs/apps.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_cbs/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class IcatCbsConfig(AppConfig):
-    name = 'icat_cbs'
+    name = "icat_cbs"

--- a/starter-kits/credential-registry/server/tob-api/icat_cbs/serializers/indy.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_cbs/serializers/indy.py
@@ -1,18 +1,6 @@
 import logging
-from datetime import datetime, timedelta
 
-import requests
-from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
-from django.core import exceptions
 from rest_framework import serializers
-
-from api_v2.auth import generate_random_username
-from api_v2.models.Credential import Credential
-from api_v2.models.CredentialType import CredentialType
-from api_v2.models.User import User
-
 
 logger = logging.getLogger(__name__)
 
@@ -25,4 +13,3 @@ class IndyAgentCallbackSerializer(serializers.Serializer):
     target_url = serializers.CharField(required=False, max_length=240)
     hook_token = serializers.CharField(required=False, max_length=240)
     registration_expiry = serializers.DateField(required=False, read_only=True)
-

--- a/starter-kits/credential-registry/server/tob-api/icat_cbs/urls.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_cbs/urls.py
@@ -2,7 +2,4 @@ from django.urls import path
 
 from icat_cbs import views
 
-
-urlpatterns = [
-    path('<topic>', views.agent_callback),
-]
+urlpatterns = [path("<topic>", views.agent_callback)]

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/hook_utils.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/hook_utils.py
@@ -1,8 +1,8 @@
+import datetime
+
 from .models.CredentialHook import CredentialHook
 from .models.HookUser import HookUser
 from .models.Subscription import Subscription
-
-import datetime
 
 
 def find_and_fire_hook(event_name, instance, **kwargs):

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/icatrestauth.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/icatrestauth.py
@@ -1,13 +1,9 @@
 import base64
 
-from django.http import HttpResponse
 from django.contrib.auth import authenticate
-from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
-from django.contrib.auth import get_user_model
-from rest_framework.authentication import BasicAuthentication
 from rest_framework import exceptions
-from rest_framework import authentication
+from rest_framework.authentication import BasicAuthentication
 
 
 class IcatAuthBackend(ModelBackend):

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/models/HookUser.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/models/HookUser.py
@@ -7,9 +7,9 @@ from api_v2.models.Auditable import Auditable
 
 class HookUser(Auditable):
     user = models.ForeignKey(
-        get_user_model(), 
+        get_user_model(),
         related_name="hook_user",
-        on_delete=django.db.models.deletion.CASCADE
+        on_delete=django.db.models.deletion.CASCADE,
     )
 
     # the following are for web hook registration

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/models/HookableCredential.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/models/HookableCredential.py
@@ -1,8 +1,9 @@
 from django.contrib.postgres import fields as contrib
 from django.db import models
 
-from .Subscription import Subscription
 from api_v2.models.Auditable import Auditable
+
+from .Subscription import Subscription
 
 
 class HookableCredential(Auditable):
@@ -24,6 +25,7 @@ class HookableCredential(Auditable):
 
     ... should fire off a hook to the feedback api
     """
+
     # corp_num = models.ForeignKey("Topic", related_name="+", to_field="source_id", on_delete=models.DO_NOTHING)
     # credential_type = models.ForeignKey("CredentialType", related_name="+", on_delete=models.DO_NOTHING)
     # 'New' or 'Stream' depending if it's the first credential for the Topic (corp_num)
@@ -42,19 +44,19 @@ class HookableCredential(Auditable):
         else:
             hook_dict = hook.dict()
         dict = {
-            'subscription': hook_dict,
-            'data': {
-                'id': self.id,
-                'corp_num': self.corp_num,
-                'credential_type': self.credential_type,
-                'credential_json': self.credential_json,
+            "subscription": hook_dict,
+            "data": {
+                "id": self.id,
+                "corp_num": self.corp_num,
+                "credential_type": self.credential_type,
+                "credential_json": self.credential_json,
                 # ... other fields here ...
-            }
+            },
         }
         print("Sending hook", dict)
         return dict
 
     class Meta:
         db_table = "hookable_cred"
-        #unique_together = (("corp_num", "credential_type"),)
+        # unique_together = (("corp_num", "credential_type"),)
         ordering = ("corp_num", "credential_type")

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/models/Subscription.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/models/Subscription.py
@@ -1,5 +1,4 @@
 from django.db import models
-from rest_hooks.models import Hook
 
 from api_v2.models.Auditable import Auditable
 from api_v2.models.User import User

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/serializers/hooks.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/serializers/hooks.py
@@ -8,13 +8,13 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core import exceptions
+from icat_hooks.models.HookUser import HookUser
 from rest_framework import serializers
 from rest_hooks.models import Hook
 
 from api_v2.auth import generate_random_username
 from api_v2.models.CredentialType import CredentialType
 from api_v2.models.User import User
-from icat_hooks.models.HookUser import HookUser
 
 from ..models.Subscription import Subscription
 

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/tests/test_hook_utils.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/tests/test_hook_utils.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-
-from api_v2.models import CredentialType, Issuer, Schema
 from icat_hooks import hook_utils
 from icat_hooks.models import CredentialHook, HookableCredential, HookUser, Subscription
+
+from api_v2.models import CredentialType, Issuer, Schema
 
 today = datetime.datetime.now().date()
 past_date = datetime.datetime.now() - datetime.timedelta(days=2)

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/tests/test_icatrestauth.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/tests/test_icatrestauth.py
@@ -3,9 +3,8 @@ from unittest.mock import Mock, patch
 from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from django.test import TestCase
-from rest_framework import exceptions
-
 from icat_hooks import icatrestauth
+from rest_framework import exceptions
 
 
 class IcatAuthBackend_TestCase(TestCase):

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/tests/test_views.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/tests/test_views.py
@@ -2,13 +2,13 @@ import json
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from icat_hooks.models.Subscription import Subscription
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from api_v2.models.CredentialType import CredentialType
 from api_v2.models.Issuer import Issuer
 from api_v2.models.Schema import Schema
-from icat_hooks.models.Subscription import Subscription
 
 
 class Icat_Hooks_Views_RegistrationCreateViewSet_TestCase(APITestCase):
@@ -281,9 +281,7 @@ class Icat_Hooks_Views_SubscriptionViewSet_TestCase(APITestCase):
         )
 
         self.assertEqual(
-            response.status_code,
-            status.HTTP_200_OK,
-            "The status code does not match.",
+            response.status_code, status.HTTP_200_OK, "The status code does not match."
         )
 
         response_content = json.loads(response.content)
@@ -319,9 +317,7 @@ class Icat_Hooks_Views_SubscriptionViewSet_TestCase(APITestCase):
         )
 
         self.assertEqual(
-            response.status_code,
-            status.HTTP_200_OK,
-            "The status code does not match.",
+            response.status_code, status.HTTP_200_OK, "The status code does not match."
         )
 
         response_content = json.loads(response.content)
@@ -359,9 +355,7 @@ class Icat_Hooks_Views_SubscriptionViewSet_TestCase(APITestCase):
         )
 
         self.assertEqual(
-            response.status_code,
-            status.HTTP_200_OK,
-            "The status code does not match.",
+            response.status_code, status.HTTP_200_OK, "The status code does not match."
         )
 
         response_content = json.loads(response.content)
@@ -388,17 +382,12 @@ class Icat_Hooks_Views_SubscriptionViewSet_TestCase(APITestCase):
             "/hooks/registration/{}/subscriptions/{}".format(
                 self.registered_user_2["credentials"]["username"], 1
             ),
-            data={
-                "subscription_type": "New",
-                "topic_source_id": "AB987654",
-            },
+            data={"subscription_type": "New", "topic_source_id": "AB987654"},
             format="json",
         )
 
         self.assertEqual(
-            response.status_code,
-            status.HTTP_200_OK,
-            "The status code does not match.",
+            response.status_code, status.HTTP_200_OK, "The status code does not match."
         )
 
         response_content = json.loads(response.content)
@@ -428,7 +417,7 @@ class Icat_Hooks_Views_SubscriptionViewSet_TestCase(APITestCase):
         response = client.delete(
             "/hooks/registration/{}/subscriptions/{}".format(
                 self.registered_user_2["credentials"]["username"], 1
-            ),
+            )
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/urls.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/urls.py
@@ -1,15 +1,13 @@
-from django.conf import settings
-from django.urls import path
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
-from rest_framework.permissions import AllowAny
+from icat_hooks.views import (
+    RegistrationCreateViewSet,
+    RegistrationViewSet,
+    SubscriptionViewSet,
+)
 from rest_framework.routers import SimpleRouter
 from rest_framework.urlpatterns import format_suffix_patterns
 
 # see https://github.com/alanjds/drf-nested-routers
 from rest_framework_nested import routers
-
-from icat_hooks.views import RegistrationCreateViewSet, RegistrationViewSet, SubscriptionViewSet
 
 router = SimpleRouter(trailing_slash=False)
 

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/views.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/views.py
@@ -3,15 +3,7 @@ import base64
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
 from rest_framework import mixins, viewsets
-
-# from rest_framework.permissions import *
-from rest_framework.permissions import (
-    BasePermission,
-    IsAuthenticated,
-    NotAuthenticated,
-    PermissionDenied,
-    authenticate,
-)
+from rest_framework.permissions import *
 
 from .icatrestauth import IcatRestAuthentication
 from .models.CredentialHook import CredentialHook

--- a/starter-kits/credential-registry/server/tob-api/icat_hooks/views.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_hooks/views.py
@@ -1,19 +1,23 @@
+import base64
+
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
-from rest_framework.permissions import *
-from rest_framework import viewsets, mixins
-from rest_hooks.models import Hook
+from rest_framework import mixins, viewsets
 
-from .models.CredentialHook import CredentialHook
-from .models.HookUser import HookUser
-from .models.Subscription import Subscription
-from .serializers.hooks import (
-    HookSerializer,
-    RegistrationSerializer,
-    SubscriptionSerializer,
+# from rest_framework.permissions import *
+from rest_framework.permissions import (
+    BasePermission,
+    IsAuthenticated,
+    NotAuthenticated,
+    PermissionDenied,
+    authenticate,
 )
 
 from .icatrestauth import IcatRestAuthentication
+from .models.CredentialHook import CredentialHook
+from .models.HookUser import HookUser
+from .models.Subscription import Subscription
+from .serializers.hooks import RegistrationSerializer, SubscriptionSerializer
 
 SUBSCRIBERS_GROUP_NAME = "subscriber"
 

--- a/starter-kits/credential-registry/server/tob-api/tob_api/auth.py
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/auth.py
@@ -2,12 +2,10 @@ import logging
 import random
 from string import ascii_lowercase, digits
 
-from django.contrib.auth.models import Group, Permission
-from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import Group
 from rest_framework import permissions
 
 from api_v2.models.User import User
-
 
 ISSUERS_GROUP_NAME = "issuers"
 
@@ -28,9 +26,7 @@ def create_issuer_user(
     except User.DoesNotExist:
         logger.debug("Creating user for DID '{0}' ...".format(issuer_did))
         if not username:
-            username = generate_random_username(
-                length=12, prefix="issuer-", split=None
-            )
+            username = generate_random_username(length=12, prefix="issuer-", split=None)
         user = User.objects.create_user(
             username,
             email=email,
@@ -61,11 +57,7 @@ def get_issuers_group():
 
 
 def generate_random_username(
-    length=16,
-    chars=ascii_lowercase + digits,
-    split=4,
-    delimiter="-",
-    prefix="",
+    length=16, chars=ascii_lowercase + digits, split=4, delimiter="-", prefix=""
 ):
     username = "".join([random.choice(chars) for i in range(length)])
 

--- a/starter-kits/credential-registry/server/tob-api/tob_api/authentication.py
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/authentication.py
@@ -10,6 +10,7 @@
     limitations under the License.
 """
 
+
 def defaults():
     """
     Utility for defining the default authentication classes

--- a/starter-kits/credential-registry/server/tob-api/tob_api/custom_settings_bcgov.py
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/custom_settings_bcgov.py
@@ -2,6 +2,7 @@
 Enclose property names in double quotes in order to JSON serialize the contents in the API
 """
 import logging
+
 from rest_framework.decorators import detail_route
 
 LOGGER = logging.getLogger(__name__)
@@ -47,7 +48,9 @@ def list_related_to_relations(self, request, pk=None):
     from rest_framework.response import Response
 
     parent_queryset = TopicRelationship.objects.filter(topic=pk).all()
-    serializer = CustomTopicRelationshipSerializer(parent_queryset, many=True, relationship_type='to')
+    serializer = CustomTopicRelationshipSerializer(
+        parent_queryset, many=True, relationship_type="to"
+    )
     return Response(serializer.data)
 
 
@@ -59,7 +62,9 @@ def list_related_from_relations(self, request, pk=None):
     from rest_framework.response import Response
 
     parent_queryset = TopicRelationship.objects.filter(related_topic=pk).all()
-    serializer = CustomTopicRelationshipSerializer(parent_queryset, many=True, relationship_type='from')
+    serializer = CustomTopicRelationshipSerializer(
+        parent_queryset, many=True, relationship_type="from"
+    )
     return Response(serializer.data)
 
 
@@ -93,20 +98,13 @@ CUSTOMIZATIONS = {
             ]
         },
         "TopicRelationship": {
-            "includeFields": [
-                "id",
-                "credential",
-                "topic",
-                "related_topic",
-            ]
+            "includeFields": ["id", "credential", "topic", "related_topic"]
         },
     },
     "views": {
-        "TopicViewSet": {
-            "includeMethods": [list_related_to, list_related_from]
-        },
+        "TopicViewSet": {"includeMethods": [list_related_to, list_related_from]},
         "TopicRelationshipViewSet": {
             "includeMethods": [list_related_to_relations, list_related_from_relations]
-        }
+        },
     },
 }

--- a/starter-kits/credential-registry/server/tob-api/tob_api/database.py
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/database.py
@@ -10,6 +10,7 @@
     limitations under the License.
 """
 import os
+
 from django.conf import settings
 
 engines = {
@@ -20,9 +21,7 @@ engines = {
 
 
 def config():
-    service_name = (
-        os.getenv("DATABASE_SERVICE_NAME", "").upper().replace("-", "_")
-    )
+    service_name = os.getenv("DATABASE_SERVICE_NAME", "").upper().replace("-", "_")
 
     if service_name:
         engine = engines.get(os.getenv("DATABASE_ENGINE"), engines["sqlite"])

--- a/starter-kits/credential-registry/server/tob-api/tob_api/haystack.py
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/haystack.py
@@ -10,41 +10,39 @@
     limitations under the License.
 """
 import os
-from django.conf import settings
 
 engines = {
-    'direct': 'haystack.backends.simple_backend.SimpleEngine',
-    'solr': 'haystack.backends.solr_backend.SolrEngine',
+    "direct": "haystack.backends.simple_backend.SimpleEngine",
+    "solr": "haystack.backends.solr_backend.SolrEngine",
 }
 
+
 def getDefaultConfig():
-    return {
-      'ENGINE': engines['direct'],
-    }
+    return {"ENGINE": engines["direct"]}
+
 
 def getSolrUrl():
-    solrUrl = os.getenv('SOLR_URL', '').lower()
+    solrUrl = os.getenv("SOLR_URL", "").lower()
     if not solrUrl:
-      serviceName = os.getenv('SOLR_SERVICE_NAME', '').upper().replace('-', '_')   
-      if serviceName:
-        coreName = os.getenv('SOLR_CORE_NAME', 'autocore')
-        serviceHost = os.getenv('{}_SERVICE_HOST'.format(serviceName))
-        servicePort = os.getenv('{}_SERVICE_PORT'.format(serviceName))
-        solrUrl = 'http://{}:{}/solr/{}'.format(serviceHost, servicePort, coreName)
+        serviceName = os.getenv("SOLR_SERVICE_NAME", "").upper().replace("-", "_")
+        if serviceName:
+            coreName = os.getenv("SOLR_CORE_NAME", "autocore")
+            serviceHost = os.getenv("{}_SERVICE_HOST".format(serviceName))
+            servicePort = os.getenv("{}_SERVICE_PORT".format(serviceName))
+            solrUrl = "http://{}:{}/solr/{}".format(serviceHost, servicePort, coreName)
 
     return solrUrl
 
+
 def getConfig():
-    config = getDefaultConfig() 
+    config = getDefaultConfig()
     solrUrl = getSolrUrl()
     if solrUrl:
-      engine = engines.get(os.getenv('SOLR_ENGINE'), engines['solr'])
-      config = {
-        'ENGINE': engine,
-        'URL': solrUrl,
-      }
+        engine = engines.get(os.getenv("SOLR_ENGINE"), engines["solr"])
+        config = {"ENGINE": engine, "URL": solrUrl}
 
     return config
+
 
 def config():
     return getConfig()

--- a/starter-kits/credential-registry/server/tob-api/tob_api/pagination.py
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/pagination.py
@@ -1,5 +1,5 @@
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 
 from django.core.paginator import Paginator
 from rest_framework.pagination import BasePagination, PageNumberPagination
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 class EnhancedPageNumberPagination(PageNumberPagination):
     page_size = 10
-    page_size_query_param = 'page_size'
+    page_size_query_param = "page_size"
     max_page_size = 20
 
     def get_paginated_response(self, data):
@@ -40,11 +40,12 @@ class ResultLimitPagination(BasePagination):
     """
     Used by autocomplete to limit the number of results
     """
+
     django_paginator_class = NullDjangoPaginator
     result_limit = 10
 
     def paginate_queryset(self, queryset, request, view=None):
-        return list(queryset[:self.result_limit])
+        return list(queryset[: self.result_limit])
 
     def get_paginated_response(self, data):
         count = len(data)

--- a/starter-kits/credential-registry/server/tob-api/tob_api/permissions.py
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/permissions.py
@@ -12,6 +12,7 @@
 
 import os
 
+
 def defaults():
     """
     Utility for defining the default permissions classes

--- a/starter-kits/credential-registry/server/tob-api/tob_api/setup.cfg
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+# https://github.com/ambv/black#line-length
+max-line-length = 88
+exclude =
+    */tests/**
+    */__init__.py
+ignore = D202, W503

--- a/starter-kits/credential-registry/server/tob-api/tob_api/views.py
+++ b/starter-kits/credential-registry/server/tob-api/tob_api/views.py
@@ -1,8 +1,5 @@
+from django.http import HttpResponse
 
-import json
-
-from django.http import HttpResponse, JsonResponse
-from django.shortcuts import render
 from api_v2.models.Credential import Credential
 
 

--- a/starter-kits/credential-registry/server/tob-api/wsgi.py
+++ b/starter-kits/credential-registry/server/tob-api/wsgi.py
@@ -15,12 +15,13 @@ framework.
 """
 import os
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tob_api.settings")
-
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tob_api.settings")
+
 application = get_wsgi_application()
 
 # Apply WSGI middleware here.


### PR DESCRIPTION
The purpose of this PR is to consolidate the python code style across the project, using `black` to format all the existing `credential-registry/server` and organizing imports/removing unused imports.

No real code changes, just a lot of noise generated by the code formatter.