### PR TITLE
Add automated performance test and operation timing information

### DIFF
--- a/agent/demo/agent.py
+++ b/agent/demo/agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import random
 import subprocess
@@ -42,6 +43,7 @@ class DemoAgent:
         external_host: str,
         label: str = None,
         timing: bool = False,
+        postgres: bool = False,
         **params,
     ):
         self.ident = ident
@@ -51,6 +53,7 @@ class DemoAgent:
         self.external_host = external_host
         self.label = label or ident
         self.timing = timing
+        self.postgres = postgres
 
         self.endpoint = f"http://{internal_host}:{http_port}"
         self.admin_url = f"http://{internal_host}:{admin_port}"
@@ -92,6 +95,30 @@ class DemoAgent:
             result.append(("--genesis-transactions", self.params["genesis"]))
         if self.timing:
             result.append("--timing")
+        if self.postgres:
+            result.extend(
+                [
+                    ("--storage-type", "postgres_storage"),
+                    (
+                        "--storage-config",
+                        json.dumps(
+                            {"url": f"{self.internal_host}:5432", "max_connections": 5}
+                        ),
+                    ),
+                    (
+                        "--storage-creds",
+                        json.dumps(
+                            {
+                                "account": "postgres",
+                                "password": "mysecretpassword",
+                                "admin_account": "postgres",
+                                "admin_password": "mysecretpassword",
+                            }
+                        ),
+                    ),
+                ]
+            )
+
         return result
 
     async def register_did(self, ledger_url=None):

--- a/agent/demo/agent.py
+++ b/agent/demo/agent.py
@@ -256,3 +256,6 @@ class DemoAgent:
             "{:35} | {:12d} {:12.3f} {:10.3f} {:10.3f} {:10.3f}".format(*row)
             for row in result
         )
+
+    async def reset_timing(self):
+        await self.admin_POST("/status/reset", text=True)

--- a/agent/demo/agent.py
+++ b/agent/demo/agent.py
@@ -1,0 +1,208 @@
+import asyncio
+import os
+import random
+import subprocess
+
+from aiohttp import web, ClientSession, ClientRequest, ClientError
+import colored
+
+COLORIZE = os.environ.get("TERM") == "xterm"
+
+
+def output_reader(handle, callback, loop, *args, **kwargs):
+    for line in iter(handle.readline, b""):
+        result = line.decode("utf-8")
+        asyncio.run_coroutine_threadsafe(callback(result, *args), loop)
+
+
+def flatten(args):
+    for arg in args:
+        if isinstance(arg, (list, tuple)):
+            yield from flatten(arg)
+        else:
+            yield arg
+
+
+class DemoAgent:
+    def __init__(
+        self,
+        ident: str,
+        http_port: int,
+        admin_port: int,
+        internal_host: str,
+        external_host: str,
+        label: str = None,
+        **params,
+    ):
+        self.ident = ident
+        self.label = label or ident
+        self.http_port = http_port
+        self.admin_port = admin_port
+        self.internal_host = internal_host
+        self.external_host = external_host
+
+        self.endpoint = f"http://{internal_host}:{http_port}"
+        self.admin_url = f"http://{internal_host}:{admin_port}"
+        self.webhook_port = None
+        self.webhook_url = None
+        self.params = params
+        self.proc = None
+        self.wh_site = None
+        self.client_session: ClientSession = ClientSession()
+
+        rand_name = str(random.randint(100_000, 999_999))
+        self.seed = (
+            self.params.get("seed")
+            or ("my_seed_000000000000000000000000" + rand_name)[-32:]
+        )
+        self.wallet_name = self.params.get("wallet_name") or self.ident + rand_name
+        self.wallet_key = self.params.get("wallet_key") or self.ident + rand_name
+        self.did = None
+
+    def get_agent_args(self):
+        result = [
+            ("--endpoint", self.endpoint),
+            ("--label", self.label),
+            "--auto-respond-messages",
+            "--accept-invites",
+            "--accept-requests",
+            "--auto-ping-connection",
+            "--auto-respond-credential-offer",
+            "--auto-respond-presentation-request",
+            ("--inbound-transport", "http", "0.0.0.0", str(self.http_port)),
+            ("--outbound-transport", "http"),
+            ("--admin", "0.0.0.0", str(self.admin_port)),
+            ("--wallet-type", self.params.get("wallet_type", "indy")),
+            ("--wallet-name", self.wallet_name),
+            ("--wallet-key", self.wallet_key),
+            ("--seed", self.seed),
+        ]
+        if "genesis" in self.params:
+            result.append(("--genesis-transactions", self.params["genesis"]))
+        return result
+
+    async def register_did(self, ledger_url=None):
+        self.log(f"Registering {self.ident} with seed {self.seed}")
+        if not ledger_url:
+            ledger_url = f"http://{self.external_host}:9000"
+        data = {"alias": self.ident, "seed": self.seed, "role": "TRUST_ANCHOR"}
+        async with self.client_session.post(
+            ledger_url + "/register", json=data
+        ) as resp:
+            assert resp.status == 200
+            nym_info = await resp.json()
+            self.did = nym_info["did"]
+        self.log(f"Got DID: {self.did}")
+
+    async def handle_output(self, output, source=""):
+        end = "" if source else "\n"
+        if source == "stderr" and COLORIZE:
+            output = colored.stylize(output, colored.fg("red"))
+        elif not source and COLORIZE:
+            output = colored.stylize(output, colored.fg("blue"))
+        print(f"{self.ident} |", output, end=end)
+
+    def log(self, msg, *, loop=None):
+        asyncio.run_coroutine_threadsafe(
+            self.handle_output(msg), loop or asyncio.get_event_loop()
+        )
+
+    def _process(self, args, env, loop):
+        proc = subprocess.Popen(
+            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        )
+        loop.run_in_executor(
+            None, output_reader, proc.stdout, self.handle_output, loop, "stdout"
+        )
+        loop.run_in_executor(
+            None, output_reader, proc.stderr, self.handle_output, loop, "stderr"
+        )
+        return proc
+
+    def get_process_args(self, scripts_dir: str):
+        return list(
+            flatten((["python3", scripts_dir + "icatagent"], self.get_agent_args()))
+        )
+
+    async def start_process(
+        self, python_path="..", scripts_dir="../scripts/", wait=True
+    ):
+        my_env = os.environ.copy()
+        my_env["PYTHONPATH"] = python_path
+
+        # refer to REST callback service
+        if self.webhook_url:
+            my_env["WEBHOOK_URL"] = self.webhook_url
+            print("Webhook url is at", my_env["WEBHOOK_URL"])
+
+        agent_args = self.get_process_args(scripts_dir)
+
+        # start agent sub-process
+        loop = asyncio.get_event_loop()
+        self.proc = await loop.run_in_executor(
+            None, self._process, agent_args, my_env, loop
+        )
+        if wait:
+            await self.detect_process()
+
+    def _terminate(self, loop):
+        if self.proc:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=0.5)
+                msg = f"== subprocess exited with rc ={self.proc.returncode}"
+            except subprocess.TimeoutExpired:
+                msg = "subprocess did not terminate in time"
+            self.log(msg, loop=loop)
+
+    async def terminate(self):
+        loop = asyncio.get_event_loop()
+        if self.proc:
+            await loop.run_in_executor(None, self._terminate, loop)
+        await self.client_session.close()
+        if self.wh_site:
+            await self.wh_site.stop()
+
+    async def listen_webhooks(self, webhook_port):
+        self.webhook_port = webhook_port
+        self.webhook_url = f"http://{self.external_host}:{str(webhook_port)}/webhooks"
+        app = web.Application()
+        app.add_routes([web.post("/webhooks/topic/{topic}/", self._receive_webhook)])
+        runner = web.AppRunner(app)
+        await runner.setup()
+        self.wh_site = web.TCPSite(runner, "0.0.0.0", webhook_port)
+        await self.wh_site.start()
+
+    async def _receive_webhook(self, request: ClientRequest):
+        topic = request.match_info["topic"]
+        payload = await request.json()
+        await self.handle_webhook(topic, payload)
+        return web.HTTPOk()
+
+    async def handle_webhook(self, topic: str, payload):
+        pass
+
+    async def admin_GET(self, path, text=False):
+        async with self.client_session.get(self.admin_url + path) as resp:
+            return await (resp.text() if text else resp.json())
+
+    async def admin_POST(self, path, data=None, text=False):
+        async with self.client_session.post(self.admin_url + path, json=data) as resp:
+            return await (resp.text() if text else resp.json())
+
+    async def detect_process(self):
+        text = None
+        for i in range(10):
+            # wait for process to start and retrieve swagger content
+            await asyncio.sleep(2.0)
+            try:
+                async with self.client_session.get(
+                    self.admin_url + "/api/docs/swagger.json"
+                ) as resp:
+                    if resp.status == 200:
+                        text = await resp.text()
+                        break
+            except ClientError:
+                text = None
+                continue
+        assert text and "Indy Catalyst Agent" in text

--- a/agent/demo/agent.py
+++ b/agent/demo/agent.py
@@ -66,11 +66,11 @@ class DemoAgent:
 
         rand_name = str(random.randint(100_000, 999_999))
         self.seed = (
-            self.params.get("seed")
-            or ("my_seed_000000000000000000000000" + rand_name)[-32:]
+            params.get("seed") or ("my_seed_000000000000000000000000" + rand_name)[-32:]
         )
-        self.wallet_name = self.params.get("wallet_name") or self.ident + rand_name
-        self.wallet_key = self.params.get("wallet_key") or self.ident + rand_name
+        self.wallet_type = params.get("wallet_type", "indy")
+        self.wallet_name = params.get("wallet_name") or self.ident.lower() + rand_name
+        self.wallet_key = params.get("wallet_key") or self.ident + rand_name
         self.did = None
 
     def get_agent_args(self):
@@ -86,7 +86,7 @@ class DemoAgent:
             ("--inbound-transport", "http", "0.0.0.0", str(self.http_port)),
             ("--outbound-transport", "http"),
             ("--admin", "0.0.0.0", str(self.admin_port)),
-            ("--wallet-type", self.params.get("wallet_type", "indy")),
+            ("--wallet-type", self.wallet_type),
             ("--wallet-name", self.wallet_name),
             ("--wallet-key", self.wallet_key),
             ("--seed", self.seed),
@@ -102,7 +102,13 @@ class DemoAgent:
                     (
                         "--storage-config",
                         json.dumps(
-                            {"url": f"{self.internal_host}:5432", "max_connections": 5}
+                            {
+                                "url": f"{self.internal_host}:5432",
+                                "tls": "None",
+                                "max_connections": 5,
+                                "min_idle_time": 0,
+                                "connection_timeout": 10,
+                            }
                         ),
                     ),
                     (

--- a/agent/demo/agent.py
+++ b/agent/demo/agent.py
@@ -68,6 +68,7 @@ class DemoAgent:
         self.seed = (
             params.get("seed") or ("my_seed_000000000000000000000000" + rand_name)[-32:]
         )
+        self.storage_type = params.get("storage_type")
         self.wallet_type = params.get("wallet_type", "indy")
         self.wallet_name = params.get("wallet_name") or self.ident.lower() + rand_name
         self.wallet_key = params.get("wallet_key") or self.ident + rand_name
@@ -93,14 +94,16 @@ class DemoAgent:
         ]
         if "genesis" in self.params:
             result.append(("--genesis-transactions", self.params["genesis"]))
+        if self.storage_type:
+            result.append(("--storage-type", self.storage_type))
         if self.timing:
             result.append("--timing")
         if self.postgres:
             result.extend(
                 [
-                    ("--storage-type", "postgres_storage"),
+                    ("--wallet-storage-type", "postgres_storage"),
                     (
-                        "--storage-config",
+                        "--wallet-storage-config",
                         json.dumps(
                             {
                                 "url": f"{self.internal_host}:5432",
@@ -112,7 +115,7 @@ class DemoAgent:
                         ),
                     ),
                     (
-                        "--storage-creds",
+                        "--wallet-storage-creds",
                         json.dumps(
                             {
                                 "account": "postgres",

--- a/agent/demo/agent.sh
+++ b/agent/demo/agent.sh
@@ -7,7 +7,7 @@ PYTHONPATH=.. ../scripts/icatagent \
  --wallet-type indy \
  --wallet-name heythere \
  --wallet-key mykey \
- --storage-type postgres_storage \
- --storage-config '{"url":"localhost:5432"}' \
- --storage-creds  '{"account":"postgres","password":"mysecretpassword","admin_account":"postgres","admin_password":"mysecretpassword"}' \
+ --wallet-storage-type postgres_storage \
+ --wallet-storage-config '{"url":"localhost:5432"}' \
+ --wallet-storage-creds  '{"account":"postgres","password":"mysecretpassword","admin_account":"postgres","admin_password":"mysecretpassword"}' \
  --admin localhost 8014

--- a/agent/demo/demo_utils.py
+++ b/agent/demo/demo_utils.py
@@ -164,9 +164,9 @@ def start_agent_subprocess(agent_name, genesis, seed, endpoint_url, in_port_1, i
             '--label', agent_name]
     use_postgres = False
     if use_postgres:
-        agent_args.extend(['--storage-type', 'postgres_storage',
-            '--storage-config', '{"url":"localhost:5432","max_connections":5}',
-            '--storage-creds',  '{"account":"postgres","password":"mysecretpassword","admin_account":"postgres","admin_password":"mysecretpassword"}',
+        agent_args.extend(['--wallet-storage-type', 'postgres_storage',
+            '--wallet-storage-config', '{"url":"localhost:5432","max_connections":5}',
+            '--wallet-storage-creds',  '{"account":"postgres","password":"mysecretpassword","admin_account":"postgres","admin_password":"mysecretpassword"}',
             ])
 
     # what are we doing?  write out to a command file

--- a/agent/demo/performance.py
+++ b/agent/demo/performance.py
@@ -259,7 +259,7 @@ async def test():
             f"Received {total} credentials in {received_time - connect_time:.2f}s"
         )
         avg = (issued_time - connect_time) / issue_count
-        alice.log(f"Average time per credential: {avg:.2f}s")
+        alice.log(f"Average time per credential: {avg:.2f}s ({1/avg:.2f}/s)")
 
         done_time = default_timer()
 

--- a/agent/demo/performance.py
+++ b/agent/demo/performance.py
@@ -1,0 +1,217 @@
+import asyncio
+import os
+import random
+import sys
+from timeit import default_timer
+
+import aiohttp
+
+from agent import DemoAgent
+
+# detect runmode and set hostnames accordingly
+run_mode = os.getenv("RUNMODE")
+
+AGENT_PORT = int(sys.argv[1])
+
+internal_host = "127.0.0.1"
+external_host = "localhost"
+scripts_dir = "../scripts/"
+
+if run_mode == "docker":
+    internal_host = "host.docker.internal"
+    external_host = "host.docker.internal"
+    scripts_dir = "scripts/"
+
+
+class BaseAgent(DemoAgent):
+    def __init__(self, ident: str, port: int, genesis: str = None):
+        super().__init__(
+            ident, port, port + 1, internal_host, external_host, genesis=genesis
+        )
+        self.connection_id = None
+        self.connection_active = asyncio.Future()
+
+    async def detect_connection(self):
+        await self.connection_active
+
+    async def handle_webhook(self, topic, payload):
+        if topic == "connections" and payload["connection_id"] == self.connection_id:
+            if payload["state"] == "active" and not self.connection_active.done():
+                self.log("Promoted to active")
+                self.connection_active.set_result(True)
+
+
+class AliceAgent(BaseAgent):
+    def __init__(self, port: int, genesis: str):
+        super().__init__("Alice", port, genesis)
+        self.credential_state = {}
+        self.credential_event = asyncio.Event()
+
+    async def get_invite(self):
+        result = await self.admin_POST("/connections/create-invitation")
+        self.connection_id = result["connection_id"]
+        return result["invitation"]
+
+    async def handle_webhook(self, topic, payload):
+        if topic == "credentials":
+            cred_id = payload["credential_exchange_id"]
+            self.credential_state[cred_id] = payload["state"]
+            self.credential_event.set()
+        await super().handle_webhook(topic, payload)
+
+    def check_received_creds(self) -> (int, int):
+        self.credential_event.clear()
+        pending = 0
+        total = len(self.credential_state)
+        for result in self.credential_state.values():
+            if result != "stored":
+                pending += 1
+        return pending, total
+
+    async def update_creds(self):
+        await self.credential_event.wait()
+
+
+class FaberAgent(BaseAgent):
+    def __init__(self, port: int, genesis):
+        super().__init__("Faber", port, genesis)
+        self.schema_id = None
+        self.credential_definition_id = None
+
+    async def receive_invite(self, invite):
+        result = await self.admin_POST("/connections/receive-invitation", invite)
+        self.connection_id = result["connection_id"]
+
+    async def publish_defs(self):
+        # create a schema
+        self.log("Publishing test schema")
+        version = format(
+            "%d.%d.%d"
+            % (random.randint(1, 101), random.randint(1, 101), random.randint(1, 101))
+        )
+        schema_body = {
+            "schema_name": "degree schema",
+            "schema_version": version,
+            "attributes": ["name", "date", "degree", "age"],
+        }
+        schema_response = await self.admin_POST("/schemas", schema_body)
+        self.schema_id = schema_response["schema_id"]
+        self.log(f"Schema ID: {self.schema_id}")
+
+        # create a cred def for the schema
+        self.log("Publishing test credential definition")
+        credential_definition_body = {"schema_id": self.schema_id}
+        credential_definition_response = await self.admin_POST(
+            "/credential-definitions", credential_definition_body
+        )
+        self.credential_definition_id = credential_definition_response[
+            "credential_definition_id"
+        ]
+        self.log(f"Credential Definition ID: {self.credential_definition_id}")
+
+    async def send_credential(self):
+        cred_attrs = {
+            "name": "Alice Smith",
+            "date": "2018-05-28",
+            "degree": "Maths",
+            "age": "24",
+        }
+        await self.admin_POST(
+            "/credential_exchange/send",
+            {
+                "credential_values": cred_attrs,
+                "connection_id": self.connection_id,
+                "credential_definition_id": self.credential_definition_id,
+            },
+        )
+
+
+async def test():
+
+    genesis = None
+
+    try:
+        if run_mode == "docker":
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"http://{external_host}:9000/genesis") as resp:
+                    genesis = await resp.text()
+        else:
+            with open("local-genesis.txt", "r") as genesis_file:
+                genesis = genesis_file.read()
+    finally:
+        if not genesis:
+            print("Error retrieving ledger genesis transactions")
+            return
+
+    alice = None
+    faber = None
+    init_time = default_timer()
+
+    try:
+        start_port = AGENT_PORT
+
+        alice = AliceAgent(start_port, genesis)
+        await alice.listen_webhooks(start_port + 2)
+        await alice.register_did()
+
+        faber = FaberAgent(start_port + 4, genesis)
+        await faber.listen_webhooks(start_port + 6)
+        await faber.register_did()
+
+        start_time = default_timer()
+        await alice.start_process(scripts_dir=scripts_dir)
+        alice.log("Started up")
+
+        await faber.start_process(scripts_dir=scripts_dir)
+        faber.log("Started up")
+
+        init_done_time = default_timer()
+
+        print(f"INIT DONE {init_done_time - start_time:.2f}s")
+
+        await faber.publish_defs()
+
+        publish_done_time = default_timer()
+
+        print(f"PUBLISH DONE {publish_done_time - init_done_time:.2f}s")
+
+        invite = await alice.get_invite()
+        await faber.receive_invite(invite)
+
+        await asyncio.wait_for(faber.detect_connection(), 5)
+
+        connect_time = default_timer()
+
+        print(f"CONNECTED {connect_time - init_done_time:.2f}s")
+
+        issue_count = 100
+
+        for idx in range(issue_count):
+            await faber.send_credential()
+
+        while True:
+            pending, total = alice.check_received_creds()
+            if total == issue_count and not pending:
+                break
+            await asyncio.wait_for(alice.update_creds(), 30)
+
+        issued_time = default_timer()
+
+        alice.log(
+            f"Received all {total} credentials in {issued_time - connect_time:.2f}s"
+        )
+        avg = (issued_time - connect_time) / issue_count
+        alice.log(f"Average time per credential: {avg:.2f}s")
+
+    finally:
+        if alice:
+            await alice.terminate()
+        if faber:
+            await faber.terminate()
+
+    done_time = default_timer()
+    print(f"Total runtime: {done_time - init_time:.2f}s")
+
+
+asyncio.get_event_loop().run_until_complete(test())
+print("Done")

--- a/agent/demo/performance.py
+++ b/agent/demo/performance.py
@@ -37,9 +37,15 @@ def log_msg(msg: str):
 
 
 class BaseAgent(DemoAgent):
-    def __init__(self, ident: str, port: int, genesis: str = None):
+    def __init__(self, ident: str, port: int, genesis: str = None, timing: bool = True):
         super().__init__(
-            ident, port, port + 1, internal_host, external_host, genesis=genesis
+            ident,
+            port,
+            port + 1,
+            internal_host,
+            external_host,
+            genesis=genesis,
+            timing=timing,
         )
         self.connection_id = None
         self.connection_active = asyncio.Future()
@@ -197,7 +203,7 @@ async def test():
 
         log_msg(f"Connect duration: {connect_time - publish_done_time:.2f}s")
 
-        issue_count = 100
+        issue_count = 300
         batch_size = 100
         batch_start = connect_time
 
@@ -233,6 +239,16 @@ async def test():
         alice.log(f"Average time per credential: {avg:.2f}s")
 
         done_time = default_timer()
+
+        timing = await alice.fetch_timing()
+        if timing:
+            for line in alice.format_timing(timing):
+                alice.log(line)
+
+        timing = await faber.fetch_timing()
+        if timing:
+            for line in faber.format_timing(timing):
+                faber.log(line)
 
     finally:
         terminated = True

--- a/agent/demo/performance.py
+++ b/agent/demo/performance.py
@@ -13,6 +13,8 @@ LOGGER = logging.getLogger(__name__)
 
 AGENT_PORT = int(sys.argv[1])
 
+POSTGRES = bool(os.getenv("POSTGRES"))
+
 # detect runmode and set hostnames accordingly
 RUN_MODE = os.getenv("RUNMODE")
 
@@ -40,7 +42,12 @@ def log_msg(msg: str):
 
 class BaseAgent(DemoAgent):
     def __init__(
-        self, ident: str, port: int, genesis: str = None, timing: bool = TIMING
+        self,
+        ident: str,
+        port: int,
+        genesis: str = None,
+        timing: bool = TIMING,
+        postgres: bool = POSTGRES,
     ):
         super().__init__(
             ident,
@@ -50,6 +57,7 @@ class BaseAgent(DemoAgent):
             external_host,
             genesis=genesis,
             timing=timing,
+            postgres=postgres,
         )
         self.connection_id = None
         self.connection_active = asyncio.Future()
@@ -60,7 +68,7 @@ class BaseAgent(DemoAgent):
     async def handle_webhook(self, topic, payload):
         if topic == "connections" and payload["connection_id"] == self.connection_id:
             if payload["state"] == "active" and not self.connection_active.done():
-                self.log("Promoted to active")
+                self.log("Connected")
                 self.connection_active.set_result(True)
 
 

--- a/agent/demo/performance.py
+++ b/agent/demo/performance.py
@@ -214,9 +214,16 @@ async def test():
         issue_count = 300
         batch_size = 100
         batch_start = connect_time
+        semaphore = asyncio.Semaphore(10)
+
+        async def send():
+            await semaphore.acquire()
+            asyncio.ensure_future(faber.send_credential()).add_done_callback(
+                lambda fut: semaphore.release()
+            )
 
         for idx in range(issue_count):
-            await faber.send_credential()
+            await send()
             if not (idx + 1) % batch_size and idx < issue_count - 1:
                 now = default_timer()
                 faber.log(

--- a/agent/demo/performance.py
+++ b/agent/demo/performance.py
@@ -154,7 +154,7 @@ async def test():
     finally:
         if not genesis:
             print("Error retrieving ledger genesis transactions")
-            return
+            sys.exit(1)
 
     alice = None
     faber = None
@@ -253,7 +253,7 @@ async def test():
     await asyncio.sleep(0.1)
 
     if not terminated:
-        raise KeyboardInterrupt()
+        os._exit(1)
 
 
 try:

--- a/agent/demo/requirements.txt
+++ b/agent/demo/requirements.txt
@@ -1,1 +1,2 @@
+colored~=1.3.93
 git+https://github.com/webpy/webpy.git#egg=web.py

--- a/agent/docker/Dockerfile.demo
+++ b/agent/docker/Dockerfile.demo
@@ -14,9 +14,12 @@ ADD setup.py ./
 
 RUN pip3 install --no-cache-dir -e .
 
-# Add and install demo code
-ADD demo ./demo
+RUN mkdir demo
 
+# Add and install demo code
+ADD demo/requirements.txt ./demo/requirements.txt
 RUN pip3 install --no-cache-dir -r demo/requirements.txt
+
+ADD demo ./demo
 
 ENTRYPOINT ["/bin/bash", "-c", "python \"$@\"", "--"]

--- a/agent/indy_catalyst_agent/__init__.py
+++ b/agent/indy_catalyst_agent/__init__.py
@@ -155,6 +155,12 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
+    "--debug-connections",
+    action="store_true",
+    help="Enable additional logging around connections",
+)
+
+PARSER.add_argument(
     "--accept-invites", action="store_true", help="Auto-accept connection invitations"
 )
 
@@ -298,6 +304,8 @@ def main():
 
     if args.debug:
         settings["debug.enabled"] = True
+    if args.debug_connections:
+        settings["debug.connections"] = True
     if args.debug_seed:
         settings["debug.seed"] = args.debug_seed
     if args.invite:

--- a/agent/indy_catalyst_agent/__init__.py
+++ b/agent/indy_catalyst_agent/__init__.py
@@ -82,6 +82,12 @@ PARSER.add_argument(
     help="Seed to use when creating the public DID",
 )
 
+PARSER.add_argument(
+    "--storage-type",
+    type=str,
+    metavar="<storage-type>",
+    help="Specify the storage implementation to use",
+)
 
 PARSER.add_argument(
     "--wallet-key",
@@ -102,14 +108,14 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
-    "--storage-type",
+    "--wallet-storage-type",
     type=str,
     metavar="<storage-type>",
-    help="Specify the storage implementation to use",
+    help="Specify the wallet storage implementation to use",
 )
 
 PARSER.add_argument(
-    "--storage-config",
+    "--wallet-storage-config",
     type=str,
     metavar="<storage-config>",
     help="Specify the storage configuration to use (required for postgres) "
@@ -117,7 +123,7 @@ PARSER.add_argument(
 )
 
 PARSER.add_argument(
-    "--storage-creds",
+    "--wallet-storage-creds",
     type=str,
     metavar="<storage-creds>",
     help="Specify the storage credentials to use (required for postgres) "
@@ -273,25 +279,27 @@ def main():
     if args.genesis_transactions:
         settings["ledger.genesis_transactions"] = args.genesis_transactions
 
+    if args.storage_type:
+        settings["storage.type"] = args.storage_type
+
     if args.seed:
         settings["wallet.seed"] = args.seed
     if args.wallet_key:
         settings["wallet.key"] = args.wallet_key
     if args.wallet_name:
         settings["wallet.name"] = args.wallet_name
+    if args.wallet_storage_type:
+        settings["wallet.storage_type"] = args.wallet_storage_type
     if args.wallet_type:
         settings["wallet.type"] = args.wallet_type
-    if args.storage_type:
-        settings["storage.type"] = args.storage_type
         # load postgres plug-in here
         # TODO where should this live?
-        if args.storage_type == "postgres_storage":
+        if args.wallet_storage_type == "postgres_storage":
             load_postgres_plugin()
-
-    if args.storage_config:
-        settings["storage.config"] = args.storage_config
-    if args.storage_creds:
-        settings["storage.creds"] = args.storage_creds
+    if args.wallet_storage_config:
+        settings["wallet.storage_config"] = args.wallet_storage_config
+    if args.wallet_storage_creds:
+        settings["wallet.storage_creds"] = args.wallet_storage_creds
 
     if args.admin:
         settings["admin.enabled"] = True

--- a/agent/indy_catalyst_agent/cache/base.py
+++ b/agent/indy_catalyst_agent/cache/base.py
@@ -33,6 +33,16 @@ class BaseCache(ABC):
         """
 
     @abstractmethod
+    async def clear(self, key: Text):
+        """
+        Remove an item from the cache, if present.
+
+        Args:
+            key: the key to remove
+
+        """
+
+    @abstractmethod
     async def flush(self):
         """Remove all items from the cache."""
 

--- a/agent/indy_catalyst_agent/cache/basic.py
+++ b/agent/indy_catalyst_agent/cache/basic.py
@@ -61,6 +61,17 @@ class BasicCache(BaseCache):
         else:
             self._cache[key] = {"expires": None, "value": value}
 
+    async def clear(self, key: Text):
+        """
+        Remove an item from the cache, if present.
+
+        Args:
+            key: the key to remove
+
+        """
+        if key in self._cache:
+            del self._cache[key]
+
     async def flush(self):
         """Remove all items from the cache."""
 

--- a/agent/indy_catalyst_agent/conductor.py
+++ b/agent/indy_catalyst_agent/conductor.py
@@ -171,16 +171,19 @@ class Conductor:
                         "get_schema",
                         "send_credential_definition",
                         "send_schema",
-                    ),
+                    )
                 )
             ),
         )
         context.injector.bind_provider(
             BaseIssuer,
-            ClassProvider(
-                "indy_catalyst_agent.issuer.indy.IndyIssuer",
-                ClassProvider.Inject(BaseWallet),
-            ),
+            StatsProvider(
+                ClassProvider(
+                    "indy_catalyst_agent.issuer.indy.IndyIssuer",
+                    ClassProvider.Inject(BaseWallet),
+                ),
+                ("create_credential_offer", "create_credential")
+            )
         )
         context.injector.bind_provider(
             BaseHolder,

--- a/agent/indy_catalyst_agent/dispatcher.py
+++ b/agent/indy_catalyst_agent/dispatcher.py
@@ -91,7 +91,7 @@ class Dispatcher:
         handler_obj = handler_cls()
         collector: Collector = await context.inject(Collector, required=False)
         if collector:
-            collector.wrap(handler_obj, "handle")
+            collector.wrap(handler_obj, "handle", ["any-message-handler"])
         handler = asyncio.ensure_future(handler_obj.handle(context, responder))
         return handler
 

--- a/agent/indy_catalyst_agent/ledger/provider.py
+++ b/agent/indy_catalyst_agent/ledger/provider.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from ..cache.base import BaseCache
 from ..classloader import ClassLoader
 from ..config.base import BaseProvider, BaseInjector, BaseSettings
 from ..wallet.base import BaseWallet
@@ -22,6 +23,11 @@ class LedgerProvider(BaseProvider):
         if genesis_transactions:
             wallet = await injector.inject(BaseWallet)
             IndyLedger = ClassLoader.load_class(self.LEDGER_CLASSES["indy"])
+            cache = await injector.inject(BaseCache, required=False)
             return IndyLedger(
-                "default", wallet, genesis_transactions, keepalive=keepalive
+                "default",
+                wallet,
+                genesis_transactions,
+                keepalive=keepalive,
+                cache=cache,
             )

--- a/agent/indy_catalyst_agent/ledger/provider.py
+++ b/agent/indy_catalyst_agent/ledger/provider.py
@@ -18,7 +18,10 @@ class LedgerProvider(BaseProvider):
         """Create and open the ledger instance."""
 
         genesis_transactions = settings.get("ledger.genesis_transactions")
+        keepalive = int(settings.get("ledger.keepalive", 5))
         if genesis_transactions:
             wallet = await injector.inject(BaseWallet)
             IndyLedger = ClassLoader.load_class(self.LEDGER_CLASSES["indy"])
-            return IndyLedger("default", wallet, genesis_transactions)
+            return IndyLedger(
+                "default", wallet, genesis_transactions, keepalive=keepalive
+            )

--- a/agent/indy_catalyst_agent/ledger/tests/test_indy.py
+++ b/agent/indy_catalyst_agent/ledger/tests/test_indy.py
@@ -36,6 +36,7 @@ class TestIndyLedger(AsyncTestCase):
         self, mock_close_pool, mock_open_ledger, mock_create_config, mock_set_proto
     ):
         ledger = IndyLedger("name", "wallet", "genesis_transactions")
+
         async with ledger as l:
             mock_set_proto.assert_called_once_with(2)
             mock_create_config.assert_called_once_with(

--- a/agent/indy_catalyst_agent/messaging/actionmenu/driver_service.py
+++ b/agent/indy_catalyst_agent/messaging/actionmenu/driver_service.py
@@ -1,6 +1,5 @@
 """Driver-based action menu service classes."""
 
-import asyncio
 import logging
 
 from ..agent_message import AgentMessage
@@ -26,14 +25,13 @@ class DriverMenuService(BaseMenuService):
             connection: The active connection record
             thread_id: The thread identifier from the requesting message.
         """
-        asyncio.ensure_future(
-            send_webhook(
-                "get-active-menu",
-                {
-                    "connection_id": connection and connection.connection_id,
-                    "thread_id": thread_id,
-                },
-            )
+        send_webhook(
+            self.context,
+            "get-active-menu",
+            {
+                "connection_id": connection and connection.connection_id,
+                "thread_id": thread_id,
+            },
         )
         return None
 
@@ -53,15 +51,14 @@ class DriverMenuService(BaseMenuService):
             connection: The active connection record
             thread_id: The thread identifier from the requesting message.
         """
-        asyncio.ensure_future(
-            send_webhook(
-                "perform-menu-action",
-                {
-                    "connection_id": connection and connection.connection_id,
-                    "thread_id": thread_id,
-                    "action_name": action_name,
-                    "action_params": action_params,
-                },
-            )
+        send_webhook(
+            self.context,
+            "perform-menu-action",
+            {
+                "connection_id": connection and connection.connection_id,
+                "thread_id": thread_id,
+                "action_name": action_name,
+                "action_params": action_params,
+            },
         )
         return None

--- a/agent/indy_catalyst_agent/messaging/basicmessage/handlers/basicmessage_handler.py
+++ b/agent/indy_catalyst_agent/messaging/basicmessage/handlers/basicmessage_handler.py
@@ -1,6 +1,8 @@
 """Basic message handler."""
 
 from ...base_handler import BaseHandler, BaseResponder, RequestContext
+from ...util import send_webhook
+
 from ..messages.basicmessage import BasicMessage
 
 
@@ -20,7 +22,8 @@ class BasicMessageHandler(BaseHandler):
 
         self._logger.info("Received basic message: %s", context.message.content)
 
-        meta = {"content": context.message.content}
+        body = context.message.content
+        meta = {"content": body}
 
         # For Workshop: mark invitations as copyable
         if context.message.content and context.message.content.startswith("http"):
@@ -30,7 +33,12 @@ class BasicMessageHandler(BaseHandler):
             context, "message", context.connection_record.DIRECTION_RECEIVED, meta
         )
 
-        body = context.message.content
+        send_webhook(
+            context,
+            "basicmessages",
+            {"message_id": context.message._id, "content": body, "state": "received"},
+        )
+
         reply = None
         if context.settings.get("debug.auto_respond_messages"):
             if (

--- a/agent/indy_catalyst_agent/messaging/credentials/handlers/credential_request_handler.py
+++ b/agent/indy_catalyst_agent/messaging/credentials/handlers/credential_request_handler.py
@@ -33,10 +33,6 @@ class CredentialRequestHandler(BaseHandler):
             context.message
         )
 
-        # We cache some stuff in order to re-issue again in the future
-        # without this roundtrip
-        await credential_manager.cache_credential_exchange(credential_exchange_record)
-
         # If auto_issue is enabled, respond immediately
         if credential_exchange_record.auto_issue:
             (

--- a/agent/indy_catalyst_agent/messaging/credentials/manager.py
+++ b/agent/indy_catalyst_agent/messaging/credentials/manager.py
@@ -88,12 +88,14 @@ class CredentialManager:
             )
 
             credential_exchange = CredentialExchange(
+                auto_issue=True,
                 connection_id=connection_id,
                 initiator=CredentialExchange.INITIATOR_SELF,
                 credential_definition_id=credential_definition_id,
                 schema_id=source_credential_exchange.schema_id,
                 credential_offer=source_credential_exchange.credential_offer,
                 credential_request=source_credential_exchange.credential_request,
+                credential_values=credential_values,
             )
             await credential_exchange.save(self.context)
 

--- a/agent/indy_catalyst_agent/messaging/credentials/models/credential_exchange.py
+++ b/agent/indy_catalyst_agent/messaging/credentials/models/credential_exchange.py
@@ -40,6 +40,7 @@ class CredentialExchange(BaseModel):
         credential_exchange_id: str = None,
         connection_id: str = None,
         thread_id: str = None,
+        parent_thread_id: str = None,
         initiator: str = None,
         state: str = None,
         credential_definition_id: str = None,
@@ -57,6 +58,7 @@ class CredentialExchange(BaseModel):
         self._id = credential_exchange_id
         self.connection_id = connection_id
         self.thread_id = thread_id
+        self.parent_thread_id = parent_thread_id
         self.initiator = initiator
         self.state = state
         self.credential_definition_id = credential_definition_id
@@ -97,6 +99,7 @@ class CredentialExchange(BaseModel):
             "auto_issue",
             "credential_values",
             "credential",
+            "parent_thread_id",
         ):
             val = getattr(self, prop)
             if val:
@@ -212,6 +215,7 @@ class CredentialExchangeSchema(BaseModelSchema):
     credential_exchange_id = fields.Str(required=False)
     connection_id = fields.Str(required=False)
     thread_id = fields.Str(required=False)
+    parent_thread_id = fields.Str(required=False)
     initiator = fields.Str(required=False)
     state = fields.Str(required=False)
     credential_definition_id = fields.Str(required=False)

--- a/agent/indy_catalyst_agent/messaging/credentials/models/credential_exchange.py
+++ b/agent/indy_catalyst_agent/messaging/credentials/models/credential_exchange.py
@@ -7,6 +7,7 @@ from typing import Sequence
 
 from marshmallow import fields
 
+from ....cache.base import BaseCache
 from ....config.injection_context import InjectionContext
 from ....storage.base import BaseStorage
 from ....storage.record import StorageRecord
@@ -139,21 +140,40 @@ class CredentialExchange(BaseModel):
             await storage.update_record_value(record, record.value)
             await storage.update_record_tags(record, record.tags)
 
+        cache_key = f"{self.RECORD_TYPE}::{self._id}"
+        cache: BaseCache = await context.inject(BaseCache, required=False)
+        if cache:
+            await cache.clear(cache_key)
+
     @classmethod
     async def retrieve_by_id(
-        cls, context: InjectionContext, credential_exchange_id: str
-    ) -> "CredentialExchange":
+        cls, context: InjectionContext, credential_exchange_id: str, cached: bool = True
+    ):
         """Retrieve a credential exchange record by ID.
 
         Args:
             context: The `InjectionContext` instance to use
             credential_exchange_id: The ID of the credential exchange record to find
+            cached: Whether to check the cache for this record
         """
-        storage: BaseStorage = await context.inject(BaseStorage)
-        result = await storage.get_record(cls.RECORD_TYPE, credential_exchange_id)
-        vals = json.loads(result.value)
-        if result.tags:
-            vals.update(result.tags)
+        cache = None
+        cache_key = f"{cls.RECORD_TYPE}::{credential_exchange_id}"
+        vals = None
+
+        if cached and credential_exchange_id:
+            cache: BaseCache = await context.inject(BaseCache, required=False)
+            if cache:
+                vals = await cache.get(cache_key)
+
+        if not vals:
+            storage: BaseStorage = await context.inject(BaseStorage)
+            result = await storage.get_record(cls.RECORD_TYPE, credential_exchange_id)
+            vals = json.loads(result.value)
+            if result.tags:
+                vals.update(result.tags)
+            if cache:
+                await cache.set(cache_key, vals, 60)
+
         return CredentialExchange(credential_exchange_id=credential_exchange_id, **vals)
 
     @classmethod

--- a/agent/indy_catalyst_agent/messaging/credentials/routes.py
+++ b/agent/indy_catalyst_agent/messaging/credentials/routes.py
@@ -265,11 +265,10 @@ async def credential_exchange_send(request: web.BaseRequest):
     if not connection_record.is_active:
         return web.HTTPForbidden()
 
-    (credential_exchange_record, message) = await credential_manager.prepare_send(
+    credential_exchange_record = await credential_manager.prepare_send(
         credential_definition_id, connection_id, credential_values
     )
-
-    await outbound_handler(message, connection_id=connection_id)
+    await credential_manager.perform_send(credential_exchange_record, outbound_handler)
 
     return web.json_response(credential_exchange_record.serialize())
 
@@ -303,11 +302,13 @@ async def credential_exchange_send_offer(request: web.BaseRequest):
     if not connection_record.is_active:
         return web.HTTPForbidden()
 
+    credential_exchange_record = await credential_manager.create_offer(
+        credential_definition_id, connection_id)
+
     (
         credential_exchange_record,
-        credential_offer_message,
-    ) = await credential_manager.create_offer(credential_definition_id, connection_id)
-
+        credential_offer_message
+    ) = await credential_manager.offer_credential(credential_exchange_record)
     await outbound_handler(credential_offer_message, connection_id=connection_id)
 
     return web.json_response(credential_exchange_record.serialize())
@@ -390,12 +391,11 @@ async def credential_exchange_issue(request: web.BaseRequest):
     if not connection_record.is_active:
         return web.HTTPForbidden()
 
+    credential_exchange_record.credential_values = credential_values
     (
         credential_exchange_record,
         credential_issue_message,
-    ) = await credential_manager.issue_credential(
-        credential_exchange_record, credential_values
-    )
+    ) = await credential_manager.issue_credential(credential_exchange_record)
 
     await outbound_handler(credential_issue_message, connection_id=connection_id)
     return web.json_response(credential_exchange_record.serialize())

--- a/agent/indy_catalyst_agent/messaging/credentials/routes.py
+++ b/agent/indy_catalyst_agent/messaging/credentials/routes.py
@@ -1,5 +1,6 @@
 """Connection handling admin routes."""
 
+import asyncio
 import json
 
 from aiohttp import web
@@ -268,7 +269,9 @@ async def credential_exchange_send(request: web.BaseRequest):
     credential_exchange_record = await credential_manager.prepare_send(
         credential_definition_id, connection_id, credential_values
     )
-    await credential_manager.perform_send(credential_exchange_record, outbound_handler)
+    asyncio.ensure_future(
+        credential_manager.perform_send(credential_exchange_record, outbound_handler)
+    )
 
     return web.json_response(credential_exchange_record.serialize())
 

--- a/agent/indy_catalyst_agent/messaging/util.py
+++ b/agent/indy_catalyst_agent/messaging/util.py
@@ -10,28 +10,82 @@ from typing import Union
 
 import aiohttp
 
+from ..config.injection_context import InjectionContext
+
 LOGGER = logging.getLogger(__name__)
 
-WEBHOOK_URL = os.environ.get("WEBHOOK_URL")
 
+class WebhookTransport:
+    """Class for managing webhook delivery."""
 
-async def send_webhook(topic, payload, retries=5):
-    """Send a webhook to WEBHOOK_URL if set."""
-    if not WEBHOOK_URL:
-        LOGGER.warning("WEBHOOK_URL is not set")
-        return
+    def __init__(
+        self, target_url: str, default_retries: int = 5, default_wait: int = 5
+    ):
+        """Initialize the WebhookTransport instance."""
+        self.target_url = target_url
+        self.client_session: aiohttp.ClientSession = None
+        self.default_retries = default_retries
+        self.default_wait = default_wait
+        self.stop_event = asyncio.Event()
 
-    async with aiohttp.ClientSession() as session:
-        full_webhook_url = f"{WEBHOOK_URL}/topic/{topic}/"
+    async def start(self):
+        """Start the transport."""
+        await self.stop_event.wait()
+
+    def stop(self):
+        """Stop the transport."""
+        self.stop_event.set()
+        if self.client_session:
+            self.client_session.close()
+            self.client_session = None
+
+    async def send(self, topic: str, payload, retries: int = None):
+        """Send a webhook to the registered endpoint."""
+        if not self.client_session:
+            self.client_session = aiohttp.ClientSession()
+        full_webhook_url = f"{self.target_url}/topic/{topic}/"
         LOGGER.info(f"Sending webhook to {full_webhook_url}")
+        if retries is None:
+            retries = self.default_retries or 0
         try:
-            response = await session.post(full_webhook_url, json=payload)
-            if response.status < 200 or response.status > 299:
-                raise Exception()
+            async with self.client_session.post(
+                full_webhook_url, json=payload
+            ) as response:
+                if response.status < 200 or response.status > 299:
+                    raise Exception()
         except Exception:
             if retries > 0:
-                await asyncio.sleep(5)
-                await send_webhook(topic, payload, retries - 1)
+                await asyncio.sleep(self.default_wait)
+                await self.send(topic, payload, retries - 1)
+
+    @classmethod
+    async def perform_send(
+        cls, context: InjectionContext, topic: str, payload, retries: int = None
+    ):
+        """Look up the registered WebhookTransport and send the message."""
+        server: WebhookTransport = await context.inject(
+            WebhookTransport, required=False
+        )
+        if server:
+            await server.send(topic, payload, retries)
+
+
+async def init_webhooks(context: InjectionContext):
+    """Register a standard WebhookTransport in the context."""
+    webhook_url = os.environ.get("WEBHOOK_URL")
+    if webhook_url:
+        context.injector.bind_instance(WebhookTransport, WebhookTransport(webhook_url))
+    else:
+        LOGGER.warning("WEBHOOK_URL is not set")
+
+
+def send_webhook(
+    context: InjectionContext, topic: str, payload, *, retries: int = None
+):
+    """Send a webhook to the active WebhookTransport if present."""
+    asyncio.ensure_future(
+        WebhookTransport.perform_send(context, topic, payload, retries)
+    )
 
 
 def datetime_to_str(dt: Union[str, datetime]) -> str:

--- a/agent/indy_catalyst_agent/stats.py
+++ b/agent/indy_catalyst_agent/stats.py
@@ -1,0 +1,181 @@
+"""Classes for tracking performance and timing."""
+
+import functools
+import inspect
+import time
+from typing import Sequence, Union
+
+
+class Stats:
+    """A collection of statistics."""
+
+    def __init__(self):
+        """Initialize the Stats instance."""
+        self.counts = {}
+        self.max_time = {}
+        self.min_time = {}
+        self.total_time = {}
+
+    def log(self, name: str, duration: float):
+        """Log an entry in the stats."""
+        if name in self.counts:
+            self.counts[name] += 1
+            self.max_time[name] = max(self.max_time[name], duration)
+            self.min_time[name] = min(self.min_time[name], duration)
+            self.total_time[name] += duration
+        else:
+            self.counts[name] = 1
+            self.max_time[name] = duration
+            self.min_time[name] = duration
+            self.total_time[name] = duration
+
+    def extract(self, names: Sequence[str] = None) -> dict:
+        """Summarize the stats in a dictionary."""
+        counts = self.counts.copy()
+        all_names = set(counts)
+        if names is None:
+            names = all_names
+            maxes = self.max_time.copy()
+            mins = self.min_time.copy()
+            totals = self.total_time.copy()
+        else:
+            names = set(names).intersection(all_names)
+            counts = {name: val for (name, val) in counts.items() if name in names}
+            maxes = {
+                name: val for (name, val) in self.max_time.items() if name in names
+            }
+            mins = {name: val for (name, val) in self.min_time.items() if name in names}
+            totals = {
+                name: val for (name, val) in self.total_time.items() if name in names
+            }
+
+        return {
+            "avg": {name: totals[name] / counts[name] for name in names},
+            "count": counts,
+            "max": maxes,
+            "min": mins,
+            "total": totals,
+        }
+
+
+class Timer:
+    """Timer instance for a running task."""
+
+    def __init__(self, collector: "Collector", groups: Sequence[str]):
+        """Initialize the Timer instance."""
+        self.collector = collector
+        self.groups = groups
+        self.start = None
+
+    @classmethod
+    def now(cls):
+        """Fetch a standard timer value."""
+        return time.perf_counter()
+
+    def __enter__(self):
+        """Enter the context manager."""
+        self.start = self.now()
+        return self
+
+    def __exit__(self, type, value, tb):
+        """Exit the context manager."""
+        dur = self.now() - self.start
+        for grp in self.groups:
+            self.collector.log(grp, dur)
+
+
+class Collector:
+    """Collector for a set of statistics."""
+
+    def __init__(self, enabled: bool = True):
+        """Initialize the Collector instance."""
+        self._enabled = enabled
+        self._stats = None
+        self.reset()
+
+    def reset(self):
+        """Reset the collector's statistics."""
+        self._stats = Stats()
+
+    @property
+    def enabled(self) -> bool:
+        """Accessor for the collector's enabled property."""
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, val: bool):
+        """Setter for the collector's enabled property."""
+        self._enabled = val
+
+    def log(self, name: str, duration: float):
+        """Log an entry in the statistics if the collector is enabled."""
+        if self._enabled:
+            self._stats.log(name, duration)
+
+    def mark(self, *names):
+        """Make a custom decorator function for adding to the set of groups."""
+        return lambda fn: self(fn, names)
+
+    def wrap(
+        self, obj, prop_name: Union[str, Sequence[str]], groups: Sequence[str] = None
+    ):
+        """Wrap a method on a class or class instance."""
+        if not prop_name:
+            return
+        if isinstance(prop_name, str):
+            method = getattr(obj, prop_name)
+            setattr(obj, prop_name, self(method, groups))
+        else:
+            for prop in prop_name:
+                self.wrap(obj, prop, groups)
+
+    def wrap_fn(self, fn, groups: Sequence[str]):
+        """Wrap a function instance to collect timing statistics on execution."""
+
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            with self.timer(*groups):
+                result = fn(*args, **kwargs)
+            return result
+
+        return wrapped
+
+    def wrap_coro(self, fn, groups: Sequence[str]):
+        """Wrap a coroutine instance to collect timing statistics on execution."""
+
+        @functools.wraps(fn)
+        async def wrapped(*args, **kwargs):
+            with self.timer(*groups):
+                result = await fn(*args, **kwargs)
+            return result
+
+        return wrapped
+
+    def __call__(self, fn, groups: Sequence[str] = None):
+        """
+        Decorate a function or class method.
+
+        Returns: a wrapped function or coroutine with automatic stats collection
+        """
+        groups = set(groups) if groups else set()
+        if inspect.iscoroutinefunction(fn):
+            groups.add(fn.__qualname__)
+            return self.wrap_coro(fn, groups)
+        elif inspect.isfunction(fn) or inspect.ismethod(fn):
+            groups.add(fn.__qualname__)
+            return self.wrap_fn(fn, groups)
+        else:
+            raise ValueError(f"Expected function or coroutine, got: {fn}")
+
+    def timer(self, *groups):
+        """Create a new timer attached to this collector."""
+        return Timer(self, groups)
+
+    @property
+    def results(self) -> dict:
+        """Accessor for the current set of collected statistics."""
+        return self._stats.extract()
+
+    def extract(self, groups: Sequence[str] = None) -> dict:
+        """Extract statistics for a specific set of groups."""
+        return self._stats.extract(groups)

--- a/agent/indy_catalyst_agent/stats.py
+++ b/agent/indy_catalyst_agent/stats.py
@@ -117,14 +117,22 @@ class Collector:
         return lambda fn: self(fn, names)
 
     def wrap(
-        self, obj, prop_name: Union[str, Sequence[str]], groups: Sequence[str] = None
+        self,
+        obj,
+        prop_name: Union[str, Sequence[str]],
+        groups: Sequence[str] = None,
+        *,
+        ignore_missing: bool = False,
     ):
         """Wrap a method on a class or class instance."""
         if not prop_name:
             return
         if isinstance(prop_name, str):
-            method = getattr(obj, prop_name)
-            setattr(obj, prop_name, self(method, groups))
+            method = getattr(obj, prop_name, None)
+            if method:
+                setattr(obj, prop_name, self(method, groups))
+            elif not ignore_missing:
+                raise KeyError(prop_name)
         else:
             for prop in prop_name:
                 self.wrap(obj, prop, groups)

--- a/agent/indy_catalyst_agent/tests/test_stats.py
+++ b/agent/indy_catalyst_agent/tests/test_stats.py
@@ -1,0 +1,87 @@
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
+
+from ..stats import Collector
+
+
+class TestStats(AsyncTestCase):
+    async def test_fn_decorator(self):
+        stats = Collector()
+
+        @stats
+        def test_fn():
+            pass
+
+        test_fn()
+        assert set(stats.results["avg"]) == {
+            "TestStats.test_fn_decorator.<locals>.test_fn"
+        }
+
+        with self.assertRaises(ValueError):
+            stats(None)
+
+    async def test_method_decorator(self):
+        stats = Collector()
+
+        class TestClass:
+            @stats
+            def test(self):
+                pass
+
+            @stats
+            async def test_async(self):
+                pass
+
+            @stats.mark("marked", "marked2")
+            def test_mark(self):
+                pass
+
+            def test_wrap(self):
+                pass
+
+        instance = TestClass()
+
+        stats.wrap(instance, "test_wrap")
+        instance.test()
+        await instance.test_async()
+        instance.test_mark()
+        instance.test_wrap()
+
+        assert set(stats.results["avg"]) == {
+            "TestStats.test_method_decorator.<locals>.TestClass.test",
+            "TestStats.test_method_decorator.<locals>.TestClass.test_async",
+            "TestStats.test_method_decorator.<locals>.TestClass.test_mark",
+            "marked",
+            "marked2",
+            "TestStats.test_method_decorator.<locals>.TestClass.test_wrap",
+        }
+
+    async def test_disable(self):
+        stats = Collector()
+        stats.enabled = False
+
+        stats.log("test", 1.0)
+        assert not set(stats.results["avg"])
+
+        stats.enabled = True
+        stats.log("test", 1.0)
+        assert stats.results["avg"] == {"test": 1.0}
+
+    async def test_extract(self):
+        stats = Collector()
+
+        stats.log("test", 1.0)
+        stats.log("test", 2.0)
+
+        results = stats.extract({"test", "a"})
+        assert results["count"] == {"test": 2}
+        assert results["total"] == {"test": 3.0}
+        assert results["avg"] == {"test": 1.5}
+        assert results["min"] == {"test": 1.0}
+        assert results["max"] == {"test": 2.0}
+
+        results = stats.extract([])
+        assert not results["avg"]
+
+        stats.reset()
+        assert not stats.results["avg"]

--- a/agent/indy_catalyst_agent/wallet/provider.py
+++ b/agent/indy_catalyst_agent/wallet/provider.py
@@ -29,13 +29,13 @@ class WalletProvider(BaseProvider):
             wallet_cfg["key"] = settings["wallet.key"]
         if "wallet.name" in settings:
             wallet_cfg["name"] = settings["wallet.name"]
-        if "storage.type" in settings:
-            wallet_cfg["storage_type"] = settings["storage.type"]
+        if "wallet.storage_type" in settings:
+            wallet_cfg["storage_type"] = settings["wallet.storage_type"]
         # storage.config and storage.creds are required if using postgres plugin
-        if "storage.config" in settings:
-            wallet_cfg["storage_config"] = settings["storage.config"]
-        if "storage.creds" in settings:
-            wallet_cfg["storage_creds"] = settings["storage.creds"]
+        if "wallet.storage_config" in settings:
+            wallet_cfg["storage_config"] = settings["wallet.storage_config"]
+        if "wallet.storage_creds" in settings:
+            wallet_cfg["storage_creds"] = settings["wallet.storage_creds"]
         wallet = ClassLoader.load_class(wallet_class)(wallet_cfg)
         await wallet.open()
         return wallet

--- a/agent/scripts/run_demo
+++ b/agent/scripts/run_demo
@@ -5,7 +5,7 @@ shopt -s nocasematch
 cd $(dirname $0)
 
 AGENT=$1
-if [[ $AGENT == "faber" ]] || [[ $AGENT == "alice" ]]; then
+if [[ $AGENT == "faber" ]] || [[ $AGENT == "alice" ]] || [[ $AGENT == "performance" ]]; then
 	echo "Preparing agent image..."
 	docker build -q -t faber-alice-demo -f ../docker/Dockerfile.demo .. || exit 1
 else
@@ -18,8 +18,12 @@ if [[ $AGENT == "faber" ]]; then
 	AGENT_FILE="demo/faber-pg.py"
 	AGENT_PORT=8020
 	AGENT_PORT_RANGE=8020-8027
-else
+elif [[ $AGENT == "alice" ]]; then
 	AGENT_FILE="demo/alice-pg.py"
+	AGENT_PORT=8030
+	AGENT_PORT_RANGE=8030-8037
+else
+	AGENT_FILE="demo/performance.py"
 	AGENT_PORT=8030
 	AGENT_PORT_RANGE=8030-8037
 fi

--- a/agent/scripts/run_demo
+++ b/agent/scripts/run_demo
@@ -28,11 +28,16 @@ else
 	AGENT_PORT_RANGE=8030-8037
 fi
 
-DOCKER_ENV="-e LOG_LEVEL=${LOG_LEVEL}"
+DOCKER_ENV="-e LOG_LEVEL=${LOG_LEVEL} -e RUNMODE=docker"
+if ! [ -z "$POSTGRES" ]; then
+	DOCKER_ENV="${DOCKER_ENV} -e POSTGRES=1 -e RUST_BACKTRACE=1"
+fi
 
 # on Windows, docker run needs to be prefixed by winpty
 if [[ "$OSTYPE" == "msys" ]]; then
-  winpty docker run --name $AGENT --rm -e RUNMODE=docker -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE $DOCKER_ENV -it faber-alice-demo $AGENT_FILE $AGENT_PORT
+	DOCKER="winpty docker"
 else
-  docker run --name $AGENT --rm -e RUNMODE=docker -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE $DOCKER_ENV -it faber-alice-demo $AGENT_FILE $AGENT_PORT
+	DOCKER=${DOCKER:-docker}
 fi
+
+$DOCKER run --name $AGENT --rm  -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE $DOCKER_ENV -it faber-alice-demo $AGENT_FILE $AGENT_PORT

--- a/agent/scripts/run_postgres
+++ b/agent/scripts/run_postgres
@@ -12,6 +12,6 @@ $DOCKER stop indy-demo-postgres &> /dev/null \
 
 $DOCKER run --rm -ti --name indy-demo-postgres \
 	-e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 \
-	-d postgres-11 \
+	-d postgres:11 \
 	-c 'log_statement=all' -c 'logging_collector=on' -c 'log_destination=stderr' \
 	-c 'log_connections=on'

--- a/agent/scripts/run_postgres
+++ b/agent/scripts/run_postgres
@@ -12,4 +12,6 @@ $DOCKER stop indy-demo-postgres &> /dev/null \
 
 $DOCKER run --rm -ti --name indy-demo-postgres \
 	-e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 \
-	-d postgres:10
+	-d postgres-11 \
+	-c 'log_statement=all' -c 'logging_collector=on' -c 'log_destination=stderr' \
+	-c 'log_connections=on'

--- a/agent/scripts/run_postgres
+++ b/agent/scripts/run_postgres
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# on Windows, docker run needs to be prefixed by winpty
+if [[ "$OSTYPE" == "msys" ]]; then
+	DOCKER="winpty docker"
+else
+	DOCKER=${DOCKER:-docker}
+fi
+
+$DOCKER stop indy-demo-postgres &> /dev/null \
+	&& echo "Stopped previous postgres container" || true
+
+$DOCKER run --rm -ti --name indy-demo-postgres \
+	-e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 \
+	-d postgres:10


### PR DESCRIPTION
New demo script: `scripts/run_demo performance`.

Updated admin endpoint `/status` now includes timing information when the agent is run with `--timing`. The `/status/reset` endpoint can be used to reset timing information.

Various optimizations to reduce the time to issue a credential.