### PR TITLE
Fixed topic attributes not displaying correctly on OrgBook UI

### DIFF
--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Topic.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Topic.py
@@ -53,10 +53,7 @@ class Topic(Auditable):
     def get_active_attributes(self):
         creds = self.get_active_credential_ids()
         if creds:
-            return Attribute.objects.filter(
-                credential_id__in=creds,
-                credential__credential_type__description="Registration",
-            )
+            return Attribute.objects.filter(credential_id__in=creds)
         return []
 
     def get_active_names(self):

--- a/starter-kits/credential-registry/server/tob-api/api_v2/serializers/search.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/serializers/search.py
@@ -4,7 +4,8 @@ import logging
 from collections import OrderedDict
 
 from django.db.models.manager import Manager
-from drf_haystack.serializers import HaystackFacetSerializer, HaystackSerializerMixin
+from drf_haystack.serializers import (HaystackFacetSerializer,
+                                      HaystackSerializerMixin)
 from rest_framework.serializers import ListSerializer, SerializerMethodField
 from rest_framework.utils.serializer_helpers import ReturnDict
 
@@ -14,22 +15,18 @@ from api_v2.models.CredentialType import CredentialType
 from api_v2.models.Issuer import Issuer
 from api_v2.models.Name import Name
 from api_v2.search_indexes import CredentialIndex
-from api_v2.serializers.rest import (
-    AddressSerializer,
-    AttributeSerializer,
-    CredentialAddressSerializer,
-    CredentialAttributeSerializer,
-    CredentialNamedTopicSerializer,
-    CredentialNameSerializer,
-    CredentialSerializer,
-    CredentialSetSerializer,
-    CredentialTopicExtSerializer,
-    CredentialTypeSerializer,
-    IssuerSerializer,
-    NameSerializer,
-    TopicRelationshipSerializer,
-    TopicSerializer,
-)
+from api_v2.serializers.rest import (AddressSerializer, AttributeSerializer,
+                                     CredentialAddressSerializer,
+                                     CredentialAttributeSerializer,
+                                     CredentialNamedTopicSerializer,
+                                     CredentialNameSerializer,
+                                     CredentialSerializer,
+                                     CredentialSetSerializer,
+                                     CredentialTopicExtSerializer,
+                                     CredentialTypeSerializer,
+                                     IssuerSerializer, NameSerializer,
+                                     TopicRelationshipSerializer,
+                                     TopicSerializer)
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +173,6 @@ class CustomTopicSerializer(TopicSerializer):
     def get_attributes(self, obj):
         attributes = Attribute.objects.filter(
             credential__topic=obj,
-            credential__credential_type__description="Registration",
             credential__latest=True,
             credential__revoked=False,
         ).order_by("credential__inactive")


### PR DESCRIPTION
Removed filter that would cause no data to be returned when retrieving Topic attributes for schemas with description different than "Registration".