### PR TITLE
Issue credential directly through API endpoint for debug

### DIFF
--- a/credential-registry/test/issueCred_direct.py
+++ b/credential-registry/test/issueCred_direct.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import argparse
+import asyncio
+import json
+import os
+import time
+
+import aiohttp
+
+RECEIVE_CREDENTIAL_URL = os.environ.get(
+    "RECEIVE_CREDENTIAL_URL", "http://localhost:8080/agentcb/debug/receive-credential/"
+)
+
+parser = argparse.ArgumentParser(
+    description="Store credentials in the Credential Registry without using an agent"
+)
+parser.add_argument("paths", nargs="+", help="the path to a credential JSON file")
+parser.add_argument(
+    "-u",
+    "--url",
+    default=RECEIVE_CREDENTIAL_URL,
+    help="the URL of the /receive-credential endpoint",
+)
+parser.add_argument(
+    "-p", "--parallel", action="store_true", help="submit the credentials in parallel"
+)
+
+args = parser.parse_args()
+
+REGISTRY_URL = args.url
+CRED_PATHS = args.paths
+PARALLEL = args.parallel
+
+
+async def issue_cred(http_client, cred_path, ident):
+    with open(cred_path) as cred_file:
+        cred_list = json.load(cred_file)
+
+    # Handle everything as a list
+    if type(cred_list) is not list:
+        cred = cred_list
+        cred_list = []
+        cred_list.append(cred)
+
+    for cred in cred_list:
+
+        raw_cred = cred["raw_credential"]
+
+        if not raw_cred:
+            raise ValueError("Credential could not be parsed")
+        schema_id = raw_cred.get("schema_id")
+        if not schema_id:
+            raise ValueError("No schema_id defined")
+        cred_def_id = raw_cred.get("cred_def_id")
+        if not cred_def_id:
+            raise ValueError("No cred_def_id defined")
+        values = raw_cred.get("schema_id")
+        if not values:
+            raise ValueError("No attribute values defined")
+
+        print("Submitting credential {} {}".format(ident, cred))
+
+        start = time.time()
+        try:
+            response = await http_client.post(REGISTRY_URL, json=cred)
+            if response.status != 200:
+                raise RuntimeError(
+                    "Credential could not be processed: {}".format(
+                        await response.text()
+                    )
+                )
+            result_json = await response.json()
+        except Exception as exc:
+            raise Exception(
+                "Could not issue credential. Is the Credential Registry running?"
+            ) from exc
+
+        elapsed = time.time() - start
+        print(
+            "Response to {} from Credential Registry ({:.2f}s):\n\n{}\n".format(
+                ident, elapsed, result_json
+            )
+        )
+
+
+async def submit_all(cred_paths, parallel=True):
+    start = time.time()
+    async with aiohttp.ClientSession() as http_client:
+        all = []
+        idx = 1
+        for cred_path in cred_paths:
+            req = issue_cred(http_client, cred_path, idx)
+            if parallel:
+                all.append(req)
+            else:
+                await req
+            idx += 1
+        if all:
+            await asyncio.gather(*all)
+    elapsed = time.time() - start
+    print("Total time: {:.2f}s".format(elapsed))
+
+
+asyncio.get_event_loop().run_until_complete(submit_all(CRED_PATHS, PARALLEL))

--- a/docker/nginx-runtime/s2i/bin/run
+++ b/docker/nginx-runtime/s2i/bin/run
@@ -64,7 +64,28 @@ read -r -d '' _CONFIG_SECTION << EOF
         }
 EOF
 
-echo "${_CONFIG_SECTION}"
+read -r -d '' _DEBUG_SECTION << EOF
+        location /agentcb/ {
+            limit_except OPTIONS {
+                ${HTTP_BASIC}
+            }
+            #proxy_set_header Authorization "";
+            ${_FORWARDED_HEADERS}
+            proxy_pass ${1%api/v2/}agentcb/;
+        }
+        location = /agentcb/ {
+            # allow access to swagger
+            #proxy_set_header Authorization "";
+            ${_FORWARDED_HEADERS}
+            proxy_pass ${1%api/v2/}agentcb/;
+        }
+EOF
+
+if [[ ! -z "${DEBUG}" ]]; then
+  echo "${_CONFIG_SECTION}${_DEBUG_SECTION}"
+else
+  echo "${_CONFIG_SECTION}"
+fi
 }
 
 getApiUrl (){

--- a/starter-kits/credential-registry/docker/docker-compose.yml
+++ b/starter-kits/credential-registry/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
   tob-web:
     image: angular-on-nginx
     environment:
+      - DEBUG=${DEBUG}
       - API_URL=${API_URL}
       - APPLICATION_URL=${APPLICATION_URL}
       - IpFilterRules=${IpFilterRules}

--- a/starter-kits/credential-registry/docker/manage
+++ b/starter-kits/credential-registry/docker/manage
@@ -380,6 +380,7 @@ configureEnvironment() {
   export STI_SCRIPTS_PATH=${STI_SCRIPTS_PATH:-/usr/libexec/s2i}
   export RUST_LOG=${RUST_LOG:-warn}
   export RUST_BACKTRACE=${RUST_BACKTRACE:-full}
+  export DEBUG=${DEBUG}
 
   # tob-db
   export POSTGRESQL_DATABASE="THE_ORG_BOOK"
@@ -414,7 +415,6 @@ configureEnvironment() {
   export DATABASE_NAME=${POSTGRESQL_DATABASE}
   export DATABASE_USER=${POSTGRESQL_USER}
   export DATABASE_PASSWORD=${POSTGRESQL_PASSWORD}
-  export DEBUG=${DEBUG}
   export DEMO_SITE=${DEMO_SITE-True}
   export DJANGO_SECRET_KEY=wpn1GZrouOryH2FshRrpVHcEhMfMLtmTWMC2K5Vhx8MAi74H5y
   export DJANGO_DEBUG=True

--- a/starter-kits/credential-registry/server/tob-api/icat_cbs/urls.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_cbs/urls.py
@@ -1,5 +1,10 @@
+from django.conf import settings
 from django.urls import path
 
-from icat_cbs import views
+from icat_cbs import views, views_debug
 
 urlpatterns = [path("topic/<topic>/", views.agent_callback)]
+
+# expose debug APIs if in debug mode 
+if settings.DEBUG:
+    urlpatterns.append(path("debug/receive-credential/", views_debug.receive_credential))

--- a/starter-kits/credential-registry/server/tob-api/icat_cbs/views.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_cbs/views.py
@@ -1,8 +1,8 @@
-import os
 import logging
+import os
 
 import requests
-
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import permissions, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
@@ -22,6 +22,7 @@ TOPIC_PERFORM_MENU_ACTION = "perform-menu-action"
 TOPIC_ISSUER_REGISTRATION = "issuer_registration"
 
 
+@swagger_auto_schema(method="post", auto_schema=None)
 @api_view(["POST"])
 @permission_classes((permissions.AllowAny,))
 def agent_callback(request, topic):
@@ -123,10 +124,10 @@ def handle_credentials(state, message):
             raw_credential = message["raw_credential"]
 
             print("Received credential:")
-            #print(raw_credential)
+            # print(raw_credential)
 
             # TODO can include this exception to test error reporting
-            #raise Exception("Depliberate error to test problem reporting")
+            # raise Exception("Depliberate error to test problem reporting")
 
             credential_data = {
                 "schema_id": raw_credential["schema_id"],
@@ -156,7 +157,7 @@ def handle_credentials(state, message):
         # TODO other scenarios
         elif state == "stored":
             print("credential stored")
-            #print(message)
+            # print(message)
 
     except Exception as e:
         LOGGER.error(str(e))

--- a/starter-kits/credential-registry/server/tob-api/icat_cbs/views_debug.py
+++ b/starter-kits/credential-registry/server/tob-api/icat_cbs/views_debug.py
@@ -1,0 +1,91 @@
+import logging
+import os
+import uuid
+
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
+
+from icat_cbs.utils.credential import Credential, CredentialManager
+
+AGENT_ADMIN_URL = os.environ.get("AGENT_ADMIN_URL")
+
+LOGGER = logging.getLogger(__name__)
+
+
+@swagger_auto_schema(
+    method="post",
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            "raw_credential": openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "schema_id": openapi.Schema(
+                        type=openapi.TYPE_STRING, description="string"
+                    ),
+                    "cred_def_id": openapi.Schema(
+                        type=openapi.TYPE_STRING, description="string"
+                    ),
+                    "values": openapi.Schema(
+                        type=openapi.TYPE_OBJECT,
+                        properties={
+                            "valN": openapi.Schema(
+                                type=openapi.TYPE_OBJECT,
+                                properties={
+                                    "raw": openapi.Schema(
+                                        type=openapi.TYPE_STRING, description="string"
+                                    )
+                                },
+                            )
+                        },
+                    ),
+                },
+            )
+        },
+    ),
+)
+@api_view(["POST"])
+@permission_classes((permissions.AllowAny,))
+def receive_credential(request):
+    """
+    Receive a stripped-down credential and store it in the credential registry.
+    This endpoint is for testing/debug purposes ONLY!
+
+    To issue a credential:
+    - use the */api/v2/credentialtype* endpoint to determine the _cred_def_id_,
+    - use the */api/v2/schema* endpoint to build the _schema_id_ in the form _origin_did:id:name:version_
+    - add the relevant attributes in the values object, using the value name as key instead of _valN_ and the string value as its _raw_ value
+    - call this API
+    """
+    message = request.data
+    credential_exchange_id = uuid.uuid4()
+    raw_credential = message["raw_credential"]
+
+    LOGGER.debug("Received raw-credential: {}".format(raw_credential))
+
+    credential_data = {
+        "schema_id": raw_credential["schema_id"],
+        "cred_def_id": raw_credential["cred_def_id"],
+        "rev_reg_id": credential_exchange_id,  # we use the same value as credential_exchange_id
+        "attrs": raw_credential["values"],
+    }
+
+    for attr in raw_credential["values"]:
+        credential_data["attrs"][attr] = raw_credential["values"][attr]["raw"]
+
+    try:
+        credential = Credential(
+            credential_data, credential_exchange_id=credential_exchange_id
+        )
+
+        credential_manager = CredentialManager()
+        credential_manager.process(credential)
+    except Exception as e:
+        LOGGER.error("An exception occurred while processing the credential:")
+        LOGGER.error(str(e))
+        return Response({"success": False, "error": str(e)})
+
+    return Response({"success": True})


### PR DESCRIPTION
Changes include a new API endpoint under `/agentcb/debug/receive-credential/` that can be used to push a credential directly to the Credential Registry. This is useful to perform load testing independently from the agent, as well as debugging more complex issues (such as the one in #327).

The `DEBUG` environment variable drives whether this endpoint is visible in the SwaggerUI and the reverse proxy configuration will let traffic through or reject the request. For this reason, the `manage` script has been updated and the `DEBUG` environment variable has been moved from the tob-api section to the "general" section as it is now related to multiple services.

Additionally, the `/agentcb/topic/` endpoint was hidden from the Swagger UI since it is a service API that is not exposed outside of the network where the services are running (traffic is not let through by the proxy anyway, unless in DEBUG mode).