### PR TITLE
Fix filtering on attributes on rest services

### DIFF
--- a/docs/create-new-credential-registry.md
+++ b/docs/create-new-credential-registry.md
@@ -1,0 +1,124 @@
+
+# Running the Indy Catalyst Credential Registry
+
+TODO overview
+
+
+## How can I run the Credential Registry?
+
+You need to have a local Indy network running, you can use VON Network which is available here:  https://github.com/bcgov/von-network
+
+```
+git clone https://github.com/bcgov/von-network.git
+cd von-network
+./manage build
+./manage start
+```
+
+Once this is running, simply clone, build and run Indy Catalyst as follows:
+
+```
+https://github.com/bcgov/indy-catalyst
+cd indy-catalyst/starter-kits/docker
+TOB_THEME_PATH=/path/to/indy-catalyst/starter-kits/credential-registry/client/tob-web/themes/ TOB_THEME=bcgov ./manage build
+TOB_THEME=bcgov ./manage start seed=my_seed_000000000000000000000123
+```
+
+Note this runs with the bcgov theme.  TO run with the default theme replace the last two commands with:
+
+```
+./manage build
+./manage start seed=my_seed_000000000000000000000123
+```
+
+
+## Is there a demo Issuer available?
+
+There is a demo Issuer available here:  https://github.com/bcgov/indy-catalyst-issuer-controller
+
+There is also a more robust Issuer available here:  https://github.com/bcgov/von-bc-registries-agent
+
+
+## How can I run the credential registry from my own fork?
+
+You will need your own fork if you intend to:
+
+- Customize the Indy Catalyst code
+- Update the code (fix bugs, add features) that you intend to submit back to bcgov
+
+Simply fork the https://github.com/bcgov/indy-catalyst repository on github to create your own fork.
+
+When you create a local clone, add the bcgov repo as an "upstream" as follows:
+
+```
+https://github.com/<you>/indy-catalyst
+cd indy-catalyst
+git remote add upstream https://github.com/bcgov/indy-catalyst
+git remote -v
+```
+
+Depending on how much you customize the Indy Catalyst code, you can keep your own fork up-do-date as follows:
+
+```
+git fetch upstream
+git merge upstream/master
+```
+
+If you made any changes to core code, you may have to manually resolve conflicts.
+
+
+## How can I customize the Credential Registry?
+
+### Customizing the User Interface
+
+The default theme and code is under the "default" theme.
+
+If you add a custom theme it will look there first.
+
+It follows standard Angular practices ...
+
+
+### Customizing the Back-end Python Code
+
+There is a "custom theme" file for the back-end Python code, examples are:
+
+- tob-api/tob_api/custom_settings_bcgov.py
+- tob-api/tob_api/custom_settings_ongov.py
+
+Just name your file "tob-api/tob_api/custom_settings_<theme>.py"
+
+Build the Credential Registry as follows (use your theme name):
+
+```
+TOB_THEME_PATH=/path/to/indy-catalyst/starter-kits/credential-registry/client/tob-web/themes/ TOB_THEME=bcgov ./manage build
+TOB_THEME=bcgov ./manage start seed=my_seed_000000000000000000000123
+```
+
+Custom settings are loaded from "tob_api/settings.py" (search for "custom_settings_file").
+
+There is some code in "api_v2/utils.py" that you can use to get custom settings (from your own code).
+
+
+### Adding a new Web Service
+
+Updates to the back-end to add a new web service:
+
+1. Add/update any models as required, and then generate migrations
+2. Add/update serializers (based on the output format of the new services)
+3. Add a view to support the service
+4. Add a URL
+5. See documentation around the "custom Python behaviour" code
+6. Not sure if the openapi.yml file is acually used ...
+
+Updates to the front end to consume the service:
+
+1. Add a mapping for the service output data to data-types.ts
+2. Shouldn't need to update general-data.service.ts
+3. Update html and typescript as necessary to consume the new service and display the results
+
+Note that there can be html in the default theme as well as your custom theme - you should only reference your custom web service in your custom theme's html.
+
+Check the following commit for an example of changes requried to add a new web service:
+
+https://github.com/bcgov/TheOrgBook/commit/89e6178e5466b8be160f7376bfc6e222a28e2633
+

--- a/starter-kits/credential-registry/server/tob-api/api_v2/models/Topic.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/models/Topic.py
@@ -55,7 +55,7 @@ class Topic(Auditable):
     def get_active_attributes(self):
         creds = self.get_active_credential_ids()
         if creds:
-            return Attribute.objects.filter(credential_id__in=creds)
+            return Attribute.objects.filter(credential_id__in=creds, credential__credential_type__description='Registration')
         return []
 
     def get_active_names(self):

--- a/starter-kits/credential-registry/server/tob-api/api_v2/serializers/search.py
+++ b/starter-kits/credential-registry/server/tob-api/api_v2/serializers/search.py
@@ -173,6 +173,7 @@ class CustomTopicSerializer(TopicSerializer):
     def get_attributes(self, obj):
         attributes = Attribute.objects.filter(
             credential__topic=obj,
+            credential__credential_type__description='Registration',
             credential__latest=True,
             credential__revoked=False,
         ).order_by("credential__inactive")


### PR DESCRIPTION
This change was made in OrgBook and never migrated to Indy Cat.

It improves performance on a couple of REST services due to incorrect filtering on credential attributes.
