### PR TITLE
Add new schema name translations to i18n resource file.

### DIFF
--- a/starter-kits/credential-registry/client/tob-web/themes/bcgov/assets/i18n/en.json
+++ b/starter-kits/credential-registry/client/tob-web/themes/bcgov/assets/i18n/en.json
@@ -11,6 +11,10 @@
       "logo-alt-text": "BC Government Logo"
     }
   },
+  "name": {
+    "registration.registries.ca": "Registration",
+    "relationship.registries.ca": "Relationship"
+  },
   "attribute": {
     "effective_dates": "Effective Dates",
     "effective_date-short": "Credential",


### PR DESCRIPTION
This adds appropriate (English) translations for the updated topic id mapping for BC registries schemas.