### PR TITLE
extended themeing engine to allow for patching

### DIFF
--- a/client/build-theme.js
+++ b/client/build-theme.js
@@ -5,6 +5,7 @@
  **/
 
 var fs = require('fs'),
+  jsonpatch = require('fast-json-patch'),
   path = require('path');
 
 var THEME_NAME = process.env.THEME || 'default';
@@ -239,6 +240,69 @@ function mergeDeep(target, ...sources) {
   return mergeDeep(target, ...sources);
 }
 
+/**
+ * allows for patching of core files in the themes folder
+ * @scope client/themes folder
+ * @param  {theme} theme directory name of the theme you are loading
+ */
+function patches( theme )
+{
+  var patchdir = path.join( __dirname, 'themes' , theme , '.patches' );
+
+  if ( fs.statSync( patchdir ) )
+  {
+      var files = fs.readdirSync( patchdir );
+      
+      for (var idx in files)
+      {
+        var patch = path.join( patchdir, files[idx]  ),
+            target = origin( files[idx] );
+
+         if ( target )
+         {
+            var patched = jsonpatch.applyPatch( require( target ) , require( patch ) ).newDocument;
+            fs.writeFileSync( target , JSON.stringify( patched, null, ' ') );
+         }
+      }
+    }
+  }
+
+  /**
+  * parses a patch filename for its targetted origin and creates a backup if one does not exist
+  * @param  {String} filename 
+  * @return {Object}           object with a path and source property
+  */
+  function origin( filename )
+  {
+    var info = filename.split('.'),
+        time = info.shift(),
+        name = info.join('.'),
+        original = path.join( __dirname, name );
+
+    if ( ! exists( original ) )
+    {
+      return false;
+    }
+
+    return original;
+
+  }
+
+  /**
+  * check if a directory/file exists in a silent/non-blocking way
+  * @param  {String} path to resource (full)
+  * @return {Boolean}     True if resource exists / False if not
+  */
+  function exists( path )
+  {
+    try {
+        fs.statSync( path );
+        return true;
+    } catch( error ) {
+        return false;
+    }
+  }
+
 // merge theme and default language files
 function combineLanguage(theme_name, target_dir) {
   var langs = new Array();
@@ -351,6 +415,9 @@ if (UPDATE_ONLY) {
 copyThemeDir('default', TARGET_DIR)
 if (THEME_NAME !== 'default') {
   copyThemeDir(THEME_NAME, TARGET_DIR)
+  
+  // Lets check for a patch directory in the custom theme
+  patches( THEME_NAME );
 }
 
 if (USE_LINKS)
@@ -360,6 +427,9 @@ combineLanguage(THEME_NAME, TARGET_DIR);
 
 let CONFIG = updateConfig(THEME_NAME);
 replaceVars(REPLACE_VAR_PATHS, CONFIG);
+
+
+
 
 if (!UPDATE_ONLY)
   console.log('Done.\n');

--- a/client/build-theme.js
+++ b/client/build-theme.js
@@ -249,7 +249,7 @@ function patches( theme )
 {
   var patchdir = path.join( __dirname, 'themes' , theme , '.patches' );
 
-  if ( fs.statSync( patchdir ) )
+  if ( exists( fs.statSync( patchdir ) ) )
   {
       var files = fs.readdirSync( patchdir );
       

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4122,6 +4122,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-json-patch": {
+      "version": "3.0.0-1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -36,6 +36,7 @@
     "compare-versions": "~3.1.0",
     "copy-webpack-plugin": "^5.1.1",
     "core-js": "~2.5.4",
+    "fast-json-patch": "^3.0.0-1",
     "font-awesome": "^4.7.0",
     "localize-router": "https://github.com/andrewwhitehead/localize-router/releases/download/v2.0.0-RC.2/localize-router-2.0.0-RC.2.tgz",
     "localize-router-http-loader": "~1.0.2",


### PR DESCRIPTION
- added new functionality to allow for theme developers to override via JSON patching angular and other  top level (themes folder) .json files

**Documentation**

In order to activate the theme overrides, you much create a ```.patches``` folder at the root of your theme folder. There is a small formatting convention to that the new functionality expects in order to read this correctly, and it is as follows;
```
2020-02-12-113055.angular.json
--- timestamp ---|--filename-- 
```
The timestamp portion helps for the sorting since patching can be sequence sensitive and the last part is filename to override. **There is not directory crawling ability (that is safely tested)** so you can only give this feature file names that are directly below the _themes_. 

**P.S:** You may theoretically be able patch lower files by adding escaped directory separators but this was not in scope for the this release so mileage may vary.

The patching leverages the ```fast-json-path``` module so please refer to that npm package for how to format and create patches [https://www.npmjs.com/package/fast-json-patch].

Signed-off-by: mario.bonito <mario.bonito@canada.ca>