### PR TITLE
Add workaround for proof performance issue

### DIFF
--- a/server/vcr-server/api/v2/views/rest.py
+++ b/server/vcr-server/api/v2/views/rest.py
@@ -221,9 +221,11 @@ class CredentialViewSet(ReadOnlyModelViewSet):
         response.raise_for_status()
         credential = response.json()
 
+        # use the credential_id in the name of the proof request - this allows the
+        # prover to short-circuit the anoncreds function to fetch the credential directly
         proof_request = {
             "version": "1.0",
-            "name": "self-verify",
+            "name": "cred_id::" + item.credential_id,
             "requested_predicates": {},
             "requested_attributes": {},
         }
@@ -232,6 +234,7 @@ class CredentialViewSet(ReadOnlyModelViewSet):
             "proof_request": proof_request,
         }
         restrictions = [{}]
+        restrictions[0]["cred_def_id"] = credential_type.credential_def_id
 
         for attr in credential_type.get_tagged_attributes():
             claim_val = credential["attrs"][attr]


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Stuff the credential id into the proof request name, and use this to short-circuit the *slow* anoncreds credential search function.
